### PR TITLE
Iptables: allow only currently connected vpn server

### DIFF
--- a/root/etc/cont-init.d/10-firewall
+++ b/root/etc/cont-init.d/10-firewall
@@ -17,14 +17,6 @@ iptables  -A OUTPUT -d `ip -o addr show dev eth0 | awk '$3 == "inet" {print $4}'
 ip6tables -A OUTPUT -d `ip -o addr show dev eth0 | awk '$3 == "inet6" {print $4}'` -j ACCEPT 2> /dev/null
 iptables  -A OUTPUT -p udp --dport 53 -j ACCEPT
 ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT 2> /dev/null
-iptables  -A OUTPUT -p tcp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null &&
-iptables  -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT || {
-    iptables  -A OUTPUT -p tcp -m tcp --dport 1194 -j ACCEPT
-    iptables  -A OUTPUT -p udp -m udp --dport 1194 -j ACCEPT; }
-ip6tables -A OUTPUT -p tcp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null &&
-ip6tables -A OUTPUT -p udp -m owner --gid-owner vpn -j ACCEPT 2>/dev/null || {
-    ip6tables -A OUTPUT -p tcp -m tcp --dport 1194 -j ACCEPT 2>/dev/null
-    ip6tables -A OUTPUT -p udp -m udp --dport 1194 -j ACCEPT 2>/dev/null; }
 
 echo "Bypass requests to NordVPN thru regular connection"
 iptables  -A OUTPUT -o eth0 -d `echo $URL_NORDVPN_API | awk -F/ '{print $3}'` -j ACCEPT


### PR DESCRIPTION
During the creation of the vpn config file a iptable rule will be added, which allows the communication to selected vpn server also the previous server rule will be deleted.
Therefore we don't need it anymore to open the udp/tcp port 1194 for all ip addresses.

Also fixes the tcp bug, which requires a connect on port 443. Until now only port 1194 was open.