### PR TITLE
Changes to allow selecting a specific server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .dccache
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .dccache
-.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,14 @@ RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
     apk --no-cache --no-progress add \
         bash=5.2.15-r0 \
-        curl=7.88.1-r1 \
+        curl=8.0.1-r2 \
         iptables=1.8.8-r2 \
         ip6tables=1.8.8-r2 \
         jq=1.6-r2 \
         shadow=4.13-r0 \
         shadow-login=4.13-r0 \
         openvpn=2.5.8-r0 \
-        bind-tools=9.18.11-r0 \
+        bind-tools=9.18.11-r1 \
         && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,13 @@ FROM alpine:3.17.3 AS rootfs-builder
 RUN echo "**** install security fix packages ****" && \
     echo "**** end run statement ****"
 
+RUN apk add dos2unix
 COPY root/ /rootfs/
+
+RUN find /rootfs -type f -exec dos2unix \;
 RUN chmod +x /rootfs/usr/bin/*
 RUN chmod +x /rootfs/etc/nordvpn/init/*
+
 COPY --from=s6-builder /s6/ /rootfs/
 
 # Main image

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ ARG TARGETPLATFORM
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    apk --no-cache --no-progress add tar xz=5.2.9-r0 && \
+    apk --no-cache --no-progress add \
+        tar=1.34-r2 \
+        xz=5.2.9-r0 \
+        && \
     echo "**** create folders ****" && \
     mkdir -p /s6 && \
     echo "**** download ${PACKAGE} ****" && \
@@ -30,13 +33,9 @@ FROM alpine:3.17.3 AS rootfs-builder
 RUN echo "**** install security fix packages ****" && \
     echo "**** end run statement ****"
 
-RUN apk add dos2unix
 COPY root/ /rootfs/
-
-RUN find /rootfs -type f -exec dos2unix \;
 RUN chmod +x /rootfs/usr/bin/*
 RUN chmod +x /rootfs/etc/nordvpn/init/*
-
 COPY --from=s6-builder /s6/ /rootfs/
 
 # Main image
@@ -52,7 +51,17 @@ ENV TECHNOLOGY=openvpn_udp \
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    apk --no-cache --no-progress add bash curl iptables ip6tables jq shadow shadow-login openvpn bind-tools && \
+    apk --no-cache --no-progress add \
+        bash=5.2.15-r0 \
+        curl=7.88.1-r1 \
+        iptables=1.8.8-r2 \
+        ip6tables=1.8.8-r2 \
+        jq=1.6-r2 \
+        shadow=4.13-r0 \
+        shadow-login=4.13-r0 \
+        openvpn=2.5.8-r0 \
+        bind-tools=9.18.11-r0 \
+        && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \
     adduser --system --uid 912 --disabled-password --no-create-home --ingroup nordvpn nordvpn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ ARG TARGETPLATFORM
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    apk --no-cache --no-progress add \
-        tar=1.34-r2 \
-        xz=5.2.9-r0 \
-        && \
+    apk --no-cache --no-progress add tar xz=5.2.9-r0 && \
     echo "**** create folders ****" && \
     mkdir -p /s6 && \
     echo "**** download ${PACKAGE} ****" && \
@@ -55,17 +52,7 @@ ENV TECHNOLOGY=openvpn_udp \
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    apk --no-cache --no-progress add \
-        bash=5.2.15-r0 \
-        curl=7.88.1-r1 \
-        iptables=1.8.8-r2 \
-        ip6tables=1.8.8-r2 \
-        jq=1.6-r2 \
-        shadow=4.13-r0 \
-        shadow-login=4.13-r0 \
-        openvpn=2.5.8-r0 \
-        bind-tools \
-        && \
+    apk --no-cache --no-progress add bash curl iptables ip6tables jq shadow shadow-login openvpn && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \
     adduser --system --uid 912 --disabled-password --no-create-home --ingroup nordvpn nordvpn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # s6 overlay builder
-FROM alpine:3.17.2 AS s6-builder
+FROM alpine:3.17.3 AS s6-builder
 
 ENV PACKAGE="just-containers/s6-overlay"
 ENV PACKAGEVERSION="3.1.4.1"
@@ -28,7 +28,7 @@ RUN echo "**** install security fix packages ****" && \
     tar -C /s6/ -Jxpf /tmp/s6-overlay-binaries.tar.xz
 
 # rootfs builder
-FROM alpine:3.17.2 AS rootfs-builder
+FROM alpine:3.17.3 AS rootfs-builder
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** end run statement ****"
@@ -39,7 +39,7 @@ RUN chmod +x /rootfs/etc/nordvpn/init/*
 COPY --from=s6-builder /s6/ /rootfs/
 
 # Main image
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 LABEL maintainer="Alexander Zinchenko <alexander@zinchenko.com>"
 
@@ -53,7 +53,7 @@ RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
     apk --no-cache --no-progress add \
         bash=5.2.15-r0 \
-        curl=7.88.1-r0 \
+        curl=7.88.1-r1 \
         iptables=1.8.8-r2 \
         ip6tables=1.8.8-r2 \
         jq=1.6-r2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,14 @@ RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
     apk --no-cache --no-progress add \
         bash=5.2.15-r0 \
-        curl=8.0.1-r2 \
+        curl=8.0.1-r0 \
         iptables=1.8.8-r2 \
         ip6tables=1.8.8-r2 \
         jq=1.6-r2 \
         shadow=4.13-r0 \
         shadow-login=4.13-r0 \
         openvpn=2.5.8-r0 \
-        bind-tools=9.18.11-r1 \
+        bind-tools=9.18.13-r0 \
         && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV TECHNOLOGY=openvpn_udp \
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    apk --no-cache --no-progress add bash curl iptables ip6tables jq shadow shadow-login openvpn && \
+    apk --no-cache --no-progress add bash curl iptables ip6tables jq shadow shadow-login openvpn bind-tools && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \
     adduser --system --uid 912 --disabled-password --no-create-home --ingroup nordvpn nordvpn && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN echo "**** install security fix packages ****" && \
         shadow=4.13-r0 \
         shadow-login=4.13-r0 \
         openvpn=2.5.8-r0 \
+        bind-tools \
         && \
     echo "**** create process user ****" && \
     addgroup --system --gid 912 nordvpn && \

--- a/root/usr/bin/createvpnconfig.sh
+++ b/root/usr/bin/createvpnconfig.sh
@@ -200,7 +200,7 @@ else
     for value in "${RA_COUNTRIES[@]}"; do
         if [[ "$value" =~ $specific_country_regex ]]; then
             hostname="${value,,}.nordvpn.com"
-            ip="$(host -t A "$hostname" | awk '{print $4}')"
+            ip="$(ping -c 1 "$hostname" | grep 'from' | awk '{print $4}' | cut -d ':' -f 1)"
             name="$(getcountryname "${value:0:2}") #${value:2}"
             constructed_json=$(printf '{"name":"%s","hostname":"%s","load":0,"station":"%s"}' "$name" "$hostname" "$ip")
             servers="$servers""$constructed_json"
@@ -241,7 +241,7 @@ name=$(echo "$servers" | jq -r '.name' | head -n 1)
 hostname=$(echo "$servers" | jq -r '.hostname' | head -n 1)
 protocol=$(getopenvpnprotocol "$TECHNOLOGY")
 
-echo "Select server \"$name\" hostname=\"$hostname\" ip=$serverip protocol=\"$protocol\""
+echo "Select server \"$name\" hostname=\"$hostname\" ip=\"$serverip\" protocol=\"$protocol\""
 
 cp "$ovpntemplatefile" "$ovpnfile"
 

--- a/root/usr/bin/createvpnconfig.sh
+++ b/root/usr/bin/createvpnconfig.sh
@@ -2,14 +2,16 @@
 
 [[ "${DEBUG,,}" == trace* ]] && set -x
 
-nvcountries=$(cat /etc/nordvpn/countries.json | jq -c '.[]')
-nvgroups=$(cat /etc/nordvpn/groups.json | jq -c '.[]')
-nvtechnologies=$(cat /etc/nordvpn/technologies.json | jq -c '.[]')
+root=""  # /mnt/e/nordvpn/root"
+
+nvcountries=$(jq -c '.[]' < "$root/etc/nordvpn/countries.json")
+nvgroups=$(jq -c '.[]' < "$root/etc/nordvpn/groups.json")
+nvtechnologies=$(jq -c '.[]' < "$root/etc/nordvpn/technologies.json")
 
 numericregex="^[0-9]+$"
+specific_country_regex="^[a-zA-Z]{2}[0-9]+$"
 
-ovpntemplatefile="/etc/nordvpn/template.ovpn"
-authfile="/tmp/auth"
+ovpntemplatefile="$root/etc/nordvpn/template.ovpn"
 ovpnfile="/tmp/nordvpn.ovpn"
 
 getcountryid()
@@ -17,7 +19,7 @@ getcountryid()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        id=$(echo "$nvcountries" | jq -r --argjson ID $input 'select(.id == $ID) | .id')
+        id=$(echo "$nvcountries" | jq -r --argjson ID "$input" 'select(.id == $ID) | .id')
     else
         id=$(echo "$nvcountries" | jq -r --arg NAME "$input" 'select(.name == $NAME) | .id')
         if [ -z "$id" ]; then
@@ -25,7 +27,7 @@ getcountryid()
         fi
     fi
 
-    printf "$id"
+    printf '%s' "$id"
 
     if [ -z "$id" ]; then
         return 1
@@ -39,7 +41,7 @@ getcountryname()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        name=$(echo "$nvcountries" | jq -r --argjson ID $input 'select(.id == $ID) | .name')
+        name=$(echo "$nvcountries" | jq -r --argjson ID "$input" 'select(.id == $ID) | .name')
     else
         name=$(echo "$nvcountries" | jq -r --arg NAME "$input" 'select(.name == $NAME) | .name')
         if [ -z "$name" ]; then
@@ -47,7 +49,7 @@ getcountryname()
         fi
     fi
 
-    printf "$name"
+    printf '%s' "$name"
 
     if [ -z "$name" ]; then
         return 1
@@ -61,7 +63,7 @@ getgroupid()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        id=$(echo "$nvgroups" | jq -r --argjson ID $input 'select(.id == $ID) | .id')
+        id=$(echo "$nvgroups" | jq -r --argjson ID "$input" 'select(.id == $ID) | .id')
     else
         id=$(echo "$nvgroups" | jq -r --arg TITLE "$input" 'select(.title == $TITLE) | .id')
         if [ -z "$id" ]; then
@@ -69,7 +71,7 @@ getgroupid()
         fi
     fi
 
-    printf "$id"
+    printf '%s' "$id"
 
     if [ -z "$id" ]; then
         return 1
@@ -83,7 +85,7 @@ getgrouptitle()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        title=$(echo "$nvgroups" | jq -r --argjson ID $input 'select(.id == $ID) | .title')
+        title=$(echo "$nvgroups" | jq -r --argjson ID "$input" 'select(.id == $ID) | .title')
     else
         title=$(echo "$nvgroups" | jq -r --arg TITLE "$input" 'select(.title == $TITLE) | .title')
         if [ -z "$id" ]; then
@@ -91,7 +93,7 @@ getgrouptitle()
         fi
     fi
 
-    printf "$title"
+    printf '%s' "$title"
 
     if [ -z "$title" ]; then
         return 1
@@ -105,7 +107,7 @@ gettechnologyid()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        id=$(echo "$nvtechnologies" | jq -r --argjson ID $input 'select(.id == $ID) | .id')
+        id=$(echo "$nvtechnologies" | jq -r --argjson ID "$input" 'select(.id == $ID) | .id')
     else
         id=$(echo "$nvtechnologies" | jq -r --arg NAME "$input" 'select(.name == $NAME) | .id')
         if [ -z "$id" ]; then
@@ -113,7 +115,7 @@ gettechnologyid()
         fi
     fi
 
-    printf "$id"
+    printf '%s' "$id"
 
     if [ -z "$id" ]; then
         return 1
@@ -127,7 +129,7 @@ gettechnologyname()
     input=$1
 
     if [[ "$input" =~ $numericregex ]]; then
-        name=$(echo "$nvtechnologies" | jq -r --argjson ID $input 'select(.id == $ID) | .name')
+        name=$(echo "$nvtechnologies" | jq -r --argjson ID "$input" 'select(.id == $ID) | .name')
     else
         name=$(echo "$nvtechnologies" | jq -r --arg NAME "$input" 'select(.name == $NAME) | .name')
         if [ -z "$id" ]; then
@@ -135,7 +137,7 @@ gettechnologyname()
         fi
     fi
 
-    printf "$name"
+    printf '%s' "$name"
 
     if [ -z "$name" ]; then
         return 1
@@ -151,7 +153,7 @@ getopenvpnprotocol()
     ident=$(echo "$nvtechnologies" | jq -r --arg NAME "$input" 'select(.name == $NAME) | .identifier')
     if [ -z "$ident" ]; then
         if [[ "$input" =~ $numericregex ]]; then
-            ident=$(echo "$nvtechnologies" | jq -r --argjson ID $input 'select(.id == $ID) | .identifier')
+            ident=$(echo "$nvtechnologies" | jq -r --argjson ID "$input" 'select(.id == $ID) | .identifier')
         fi
     fi
     if [ -z "$ident" ]; then
@@ -179,10 +181,10 @@ echo "Apply filter technology \"$(gettechnologyname "$TECHNOLOGY")\""
 filterserver="filters\[servers_technologies\]\[id\]=$(gettechnologyid "$TECHNOLOGY")"
 
 IFS=';'
-read -ra RA_GROUPS <<< $GROUP
+read -ra RA_GROUPS <<< "$GROUP"
 for value in "${RA_GROUPS[@]}"; do
-    if [ ! -z "$value" ]; then
-        echo "Apply filter group \"$(getgrouptitle $value)\""
+    if [ -n "$value" ]; then
+        echo "Apply filter group \"$(getgrouptitle "$value")\""
         filterserver="$filterserver""&filters\[servers_groups\]\[id\]=$(getgroupid "$value")"
     fi
 done
@@ -191,15 +193,21 @@ servers=""
 
 echo "Request list of recommended servers"
 if [ -z "$COUNTRY" ]; then
-    servers=$(curl -s "https://api.nordvpn.com/v1/servers/recommendations?"$filterserver"" | jq -c '.[]')
-    echo "Request nearest servers, "$(echo "$servers" | jq -s 'length')" servers received"
+    servers=$(curl -s "https://api.nordvpn.com/v1/servers/recommendations?$filterserver" | jq -c '.[]')
+    echo "Request nearest servers, $(echo "$servers" | jq -s 'length') servers received"
 else
-    read -ra RA_COUNTRIES <<< $COUNTRY
+    read -ra RA_COUNTRIES <<< "$COUNTRY"
     for value in "${RA_COUNTRIES[@]}"; do
-        if [ ! -z "$value" ]; then
-            countryid=$(getcountryid $value)
-            serversincountry=$(curl -s "https://api.nordvpn.com/v1/servers/recommendations?"$filterserver"&filters\[country_id\]="$countryid"" | jq -c '.[]')
-            echo "Request servers in \"$(getcountryname "$value")\", "$(echo "$serversincountry" | jq -s 'length')" servers received"
+        if [[ "$value" =~ $specific_country_regex ]]; then
+            hostname="${value,,}.nordvpn.com"
+            ip="$(host -t A "$hostname" | awk '{print $4}')"
+            name="$(getcountryname "${value:0:2}") #${value:2}"
+            constructed_json=$(printf '{"name":"%s","hostname":"%s","load":0,"station":"%s"}' "$name" "$hostname" "$ip")
+            servers="$servers""$constructed_json"
+        elif [ -n "$value" ]; then
+            countryid=$(getcountryid "$value")
+            serversincountry=$(curl -s "https://api.nordvpn.com/v1/servers/recommendations?$filterserver&filters\[country_id\]=$countryid" | jq -c '.[]')
+            echo "Request servers in \"$(getcountryname "$value")\", $(echo "$serversincountry" | jq -s 'length') servers received"
             servers="$servers""$serversincountry"
         fi
     done
@@ -208,19 +216,19 @@ fi
 poollength=$(echo "$servers" | jq -s 'unique | length')
 servers=$(echo "$servers" | jq -s -c 'unique | sort_by(.load) | .[]')
 
-if [[ !($RANDOM_TOP -eq 0) ]]; then
+if [[ ! ($RANDOM_TOP -eq 0) ]]; then
     if [[ $RANDOM_TOP -lt poollength ]]; then
-        filtered=$(echo $servers | head -n $RANDOM_TOP | shuf)
-        servers="$filtered"$(echo $servers | tail -n +$((RANDOM_TOP + 1)))
+        filtered=$(echo "$servers" | head -n "$RANDOM_TOP" | shuf)
+        servers="$filtered"$(echo "$servers" | tail -n +$((RANDOM_TOP + 1)))
     else
-        servers=$(echo $servers | shuf)
+        servers=$(echo "$servers" | shuf)
     fi
 fi
 
 echo "$poollength"" recommended servers in pool"
-if [[ !($poollength -eq 0) ]]; then
+if [[ ! ($poollength -eq 0) ]]; then
     echo "--- Top 20 servers in filtered pool ---"
-    echo $(echo $servers | jq -r '[.hostname, .load] | "\(.[0]): \(.[1])"' | head -n 20)
+    echo "$servers" | jq -r '[.hostname, .load] | "\(.[0]): \(.[1])"' | head -n 20
     echo "---------------------------------------"
 fi
 
@@ -228,12 +236,12 @@ if [[ $poollength -eq 0 ]]; then
     echo "ERROR: list of selected servers is empty"
 fi
 
-serverip=$(echo $servers | jq -r '.station' | head -n 1)
-name=$(echo $servers | jq -r '.name' | head -n 1)
-hostname=$(echo $servers | jq -r '.hostname' | head -n 1)
+serverip=$(echo "$servers" | jq -r '.station' | head -n 1)
+name=$(echo "$servers" | jq -r '.name' | head -n 1)
+hostname=$(echo "$servers" | jq -r '.hostname' | head -n 1)
 protocol=$(getopenvpnprotocol "$TECHNOLOGY")
 
-echo "Select server \""$name"\" hostname=\""$hostname"\" ip="$serverip" protocol=\""$protocol"\""
+echo "Select server \"$name\" hostname=\"$hostname\" ip=$serverip protocol=\"$protocol\""
 
 cp "$ovpntemplatefile" "$ovpnfile"
 
@@ -246,7 +254,7 @@ if [[ "$protocol" == "udp" ]]; then
 elif [[ "$protocol" == "tcp" ]]; then
     sed -i "s/__PORT__/443/g" "$ovpnfile"
 else
-    echo "ERROR: TECHNOLOGY environment variable contains wrong parameter \""$TECHNOLOGY"\""
+    echo "ERROR: TECHNOLOGY environment variable contains wrong parameter \"$TECHNOLOGY\""
 fi
 
 exit 0

--- a/root/usr/bin/createvpnconfig.sh
+++ b/root/usr/bin/createvpnconfig.sh
@@ -200,7 +200,7 @@ else
     for value in "${RA_COUNTRIES[@]}"; do
         if [[ "$value" =~ $specific_country_regex ]]; then
             hostname="${value,,}.nordvpn.com"
-            ip="$(ping -c 1 "$hostname" | grep 'from' | awk '{print $4}' | cut -d ':' -f 1)"
+            ip="$(host -t A "$hostname" | awk '{print $4}')"
             name="$(getcountryname "${value:0:2}") #${value:2}"
             constructed_json=$(printf '{"name":"%s","hostname":"%s","load":0,"station":"%s"}' "$name" "$hostname" "$ip")
             servers="$servers""$constructed_json"

--- a/root/usr/bin/createvpnconfig.sh
+++ b/root/usr/bin/createvpnconfig.sh
@@ -2,16 +2,14 @@
 
 [[ "${DEBUG,,}" == trace* ]] && set -x
 
-root=""  # /mnt/e/nordvpn/root"
-
-nvcountries=$(jq -c '.[]' < "$root/etc/nordvpn/countries.json")
-nvgroups=$(jq -c '.[]' < "$root/etc/nordvpn/groups.json")
-nvtechnologies=$(jq -c '.[]' < "$root/etc/nordvpn/technologies.json")
+nvcountries=$(jq -c '.[]' < "/etc/nordvpn/countries.json")
+nvgroups=$(jq -c '.[]' < "/etc/nordvpn/groups.json")
+nvtechnologies=$(jq -c '.[]' < "/etc/nordvpn/technologies.json")
 
 numericregex="^[0-9]+$"
 specific_country_regex="^[a-zA-Z]{2}[0-9]+$"
 
-ovpntemplatefile="$root/etc/nordvpn/template.ovpn"
+ovpntemplatefile="/etc/nordvpn/template.ovpn"
 ovpnfile="/tmp/nordvpn.ovpn"
 
 getcountryid()


### PR DESCRIPTION
Changes in this PR:
- Allow selecting a specific server instead of getting a random server. ( fixes #139 ) [Added `bind-tools` package so I could use `host`. I tried via `ping`, but I always got errors with that.]

- Security upgrade of alpine (I saw other PRs open to do just that same thing)
- Upgrade of curl to `r1`. `r0` would break the build
- Cleaned up the main script to:
   * removal of double quoting (for example "some ""$var"" defined" can be written as "some $var defined".
   * adding of quoting to ensure correctness [for example `$(getgrouptitle $value)` --> `$(getgrouptitle "$value")`
   * `! -z` --> `-n`


The main change is the first bit.

So now I could call the container with `--env "COUNTRY=DE205"` and I'll always be getting that exact server (faked the load to be 0 so it's on top of the list).