### PR TITLE
Updated United Kingdom country code from GB to UK

### DIFF
--- a/COUNTRIES.md
+++ b/COUNTRIES.md
@@ -59,6 +59,6 @@ Thailand | TH | 214
 Turkey | TR | 220
 Ukraine | UA | 225
 United Arab Emirates | AE | 226
-United Kingdom | GB | 227
+United Kingdom | UK | 227
 United States | US | 228
 Vietnam | VN | 234


### PR DESCRIPTION
I've observed that when fetching NordVPN OpenVPN configurations, that the country code for United Kingdom has changed from 'GB' to 'UK'.