### PR TITLE
Potential fix for code scanning alert no. 693: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -1,5 +1,9 @@
 name: Update NordVPN readme files
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: 0 3 * * *


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/693](https://github.com/azinchen/nordvpn/security/code-scanning/693)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves creating pull requests and updating files, the permissions should include `contents: write` and `pull-requests: write`. Adding the `permissions` block at the root level of the workflow ensures that all jobs inherit these permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
