### PR TITLE
Potential fix for code scanning alert no. 690: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_configs.yml
+++ b/.github/workflows/update_configs.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 0 3 * * *
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update_ovpn:
     name: Update OpenVPN template file


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/690](https://github.com/azinchen/nordvpn/security/code-scanning/690)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- The `contents: read` permission is needed to allow the workflow to read repository contents.
- The `pull-requests: write` permission is required for the `peter-evans/create-pull-request` action to create and manage pull requests.

The `permissions` block will be added at the root level of the workflow file to apply to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
