### PR TITLE
Potential fix for code scanning alert no. 687: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Build and Deploy image
 on:
   push:
 
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
 env:
   PLATFORMS: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x"
 


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/687](https://github.com/azinchen/nordvpn/security/code-scanning/687)

To fix the issue, we need to explicitly define the permissions for the workflow. The `permissions` key should be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs to tailor permissions for specific tasks. In this case, the minimal permissions required for the workflow are:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to GitHub Container Registry.
- `actions: read` for using actions.

The `permissions` block will be added at the root level of the workflow to ensure all jobs inherit the least privilege permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
