### PR TITLE
Potential fix for code scanning alert no. 685: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-apk-versions.yml
+++ b/.github/workflows/update-apk-versions.yml
@@ -1,4 +1,7 @@
 name: Update APK Versions
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/685](https://github.com/azinchen/nordvpn/security/code-scanning/685)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow:
- `contents: write` is needed for the `actions/checkout` step and to commit changes.
- `pull-requests: write` is required for the `peter-evans/create-pull-request` action to create and manage pull requests.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
