### PR TITLE
Potential fix for code scanning alert no. 684: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image-security.yml
+++ b/.github/workflows/docker-image-security.yml
@@ -1,4 +1,6 @@
 name: Docker Image Security Analysis
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/684](https://github.com/azinchen/nordvpn/security/code-scanning/684)

To address the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since the workflow uploads SARIF files to the GitHub Security tab, no additional write permissions are necessary.

The `permissions` block will be added immediately after the `name` field at the top of the file. This ensures that the permissions apply to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
