### PR TITLE
Potential fix for code scanning alert no. 682: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -1,5 +1,10 @@
 name: Security Analysis
 
+permissions:
+  contents: read
+  security-events: write
+  issues: write
+
 on:
   schedule:
     - cron: 0 4 * * *


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/682](https://github.com/azinchen/nordvpn/security/code-scanning/682)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow, the following permissions are likely required:
- `contents: read` for accessing repository contents.
- `security-events: write` for uploading SARIF files to the GitHub Security tab.
- `issues: write` for creating or updating issues in the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
