### PR TITLE
Potential fix for code scanning alert no. 681: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package_versions.yml
+++ b/.github/workflows/package_versions.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: 0 3 * * *
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update_github_releases:
     name: Update github package versions


### PR DESCRIPTION
Potential fix for [https://github.com/azinchen/nordvpn/security/code-scanning/681](https://github.com/azinchen/nordvpn/security/code-scanning/681)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions (e.g., checking out code, reading repository tags, modifying files, and creating pull requests), the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`update_github_releases`) to scope permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
