### PR TITLE
Fix GitHub Actions workflow permissions causing update_configs.yml failures

### DIFF
--- a/.github/workflows/update_configs.yml
+++ b/.github/workflows/update_configs.yml
@@ -5,7 +5,7 @@ on:
     - cron: 0 3 * * *
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Problem

The `update_configs.yml` GitHub Actions workflow has been consistently failing for the past 6 days with permission errors:

```
remote: Permission to azinchen/nordvpn.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/azinchen/nordvpn/': The requested URL returned error: 403
```

## Root Cause

The workflow was configured with `contents: read` permission, but the `peter-evans/create-pull-request` action requires `contents: write` permission to:
- Create new branches
- Push commits to those branches  
- Create pull requests from those branches

## Changes Made

- Changed permissions in `.github/workflows/update_configs.yml` from `contents: read` to `contents: write`

## Testing

After this change, the workflow will be able to:
- Successfully create branches for config updates
- Push commits to those branches
- Create pull requests for automated updates

## Related Issue

Fixes #686

## Impact

This will restore the automated updates for:
- OpenVPN template files (`template.ovpn`)
- Countries JSON (`countries.json`)  
- Groups JSON (`groups.json`)
- Technologies JSON (`technologies.json`)