### PR TITLE
Fix crond service dependencies for proper initialization order

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/crond/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/crond/dependencies
@@ -1,1 +1,7 @@
-container-init
+init-adduser
+init-firewall
+init-localnetwork
+init-whitelistnetwork
+init-createvpnconfig
+init-setupcron
+init-createauth


### PR DESCRIPTION
## Issue Description

Fixes #728 

The crond service currently only depends on `container-init`, which is insufficient for proper service startup order. This can lead to timing issues where crond starts before essential initialization services are complete.

## Changes Made

Updated the crond service dependencies from a single `container-init` dependency to include all necessary initialization services:

- `init-adduser` - User setup must complete first
- `init-firewall` - Firewall configuration is required  
- `init-localnetwork` - Local network setup needed
- `init-whitelistnetwork` - Network whitelisting must be configured
- `init-createvpnconfig` - VPN configuration creation is essential
- `init-setupcron` - Cron setup must complete before crond starts
- `init-createauth` - Authentication setup is required

## Benefits

- Ensures proper service startup order
- Prevents race conditions during container initialization
- Improves reliability of the NordVPN container
- Follows s6-overlay best practices for service dependencies

## Testing

This change has been tested to ensure crond starts only after all required initialization services have completed successfully.

Fixes the service dependency chain for the crond service in the NordVPN Docker container.