### PR TITLE
Fix: Remove 'v' prefix from Docker tag names for production releases

### DIFF
--- a/.github/workflows/ci-build-deploy.yml
+++ b/.github/workflows/ci-build-deploy.yml
@@ -62,7 +62,8 @@ jobs:
           
           # Get clean branch/tag name
           if [[ "$IS_TAG" == "true" ]]; then
-            IMAGE_TAG=${GITHUB_REF_NAME}
+            # Remove 'v' prefix from tag name for production releases
+            IMAGE_TAG=${GITHUB_REF_NAME#v}
             PLATFORMS="${{ env.PLATFORMS }}"  # Build all platforms for tags
             PUSH_TO_PROD=true
           elif [[ "$GITHUB_REF_NAME" == "master" ]]; then


### PR DESCRIPTION
## Description
This PR fixes the Docker tag naming inconsistency by removing the 'v' prefix from container image tags for production releases.

## Problem
Currently, when Git tags are created with a 'v' prefix (e.g., ), the Docker container images are also tagged with the 'v' prefix, which is inconsistent with Docker tagging best practices.

## Solution
Modified the CI/CD workflow in  to strip the 'v' prefix from tag names when creating Docker image tags for production releases using bash parameter expansion `${GITHUB_REF_NAME#v}`.

## Changes
- **Before**: `IMAGE_TAG=${GITHUB_REF_NAME}` (uses tag name as-is)
- **After**: `IMAGE_TAG=${GITHUB_REF_NAME#v}` (removes 'v' prefix if present)

## Expected Behavior
- Git tag: `v1.0.0` → Docker tag: `1.0.0`
- Git tag: `1.0.0` → Docker tag: `1.0.0`

## Testing
- [x] Workflow modification syntax is correct
- [x] Change only affects production builds (tags)
- [x] Development and branch builds remain unchanged
- [x] Both DockerHub and GHCR registries will receive consistent tag names

## Impact
- ✅ Ensures consistent Docker tag naming regardless of Git tag format
- ✅ Follows Docker best practices for version tagging
- ✅ No breaking changes to existing functionality
- ✅ Backward compatible with tags without 'v' prefix

Fixes #741