### PR TITLE
Add dependencies file for init-createauth service

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-createauth/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/init-createauth/dependencies
@@ -1,0 +1,1 @@
+init-adduser


### PR DESCRIPTION
## Description
Fixes #743

This PR adds the missing dependencies file for the init-createauth service in the s6-overlay configuration.

## Changes
- Added `root/etc/s6-overlay/s6-rc.d/init-createauth/dependencies` file
- Specifies `init-adduser` as a prerequisite service

## Why This Change is Needed
The init-createauth service was missing its dependencies file, which could lead to improper service initialization order. Without this file, the service might start before its prerequisite services, potentially causing initialization failures.

## Testing
- [x] Verified the dependencies file format is correct
- [x] Ensured proper service dependency chain

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings