### PR TITLE
Refactor iptables backend selection to reduce code duplication

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -6,8 +6,7 @@ set -eu
 echo "[INIT-FIREWALL] Starting init-firewall script..."
 echo "[INIT-FIREWALL] Setting up firewall - everything has to go through the VPN"
 
-# Reuse backend selected by entrypoint
-[ -r /run/xt/backend.env ] && . /run/xt/backend.env
+. /usr/local/bin/backend_functions
 
 add4() { if ! $IPT "$@" 2>/dev/null; then echo "[INIT-FIREWALL] (IPv4) skipped: $*"; fi; }
 

--- a/root/etc/s6-overlay/s6-rc.d/nordvpnd/run
+++ b/root/etc/s6-overlay/s6-rc.d/nordvpnd/run
@@ -10,8 +10,7 @@ authfile="/run/xt/auth"
 ovpnfile="/run/xt/nordvpn.ovpn"
 OPENVPN_OPTS="${OPENVPN_OPTS:-}"
 
-# Reuse backend selected by entrypoint
-[ -r /run/xt/backend.env ] && . /run/xt/backend.env
+. /usr/local/bin/backend_functions
 
 # -------- helpers --------
 ensure_tun()

--- a/root/usr/local/bin/backend_functions
+++ b/root/usr/local/bin/backend_functions
@@ -1,0 +1,19 @@
+#!/bin/sh
+# shellcheck shell=sh
+
+# Reuse backend selected by entrypoint
+[ -r /run/xt/backend.env ] && . /run/xt/backend.env
+
+run4() {
+    if ! ${IPT} "$@" 2>/dev/null; then
+        echo "[ENTRYPOINT] (IPv4) skipped: $*"
+    fi
+}
+
+run6() {
+    if [ -n "$IP6T" ]; then
+        if ! ${IP6T} "$@" 2>/dev/null; then
+            echo "[ENTRYPOINT] (IPv6) skipped: $*"
+        fi
+    fi
+}

--- a/root/usr/local/bin/entrypoint
+++ b/root/usr/local/bin/entrypoint
@@ -33,7 +33,7 @@ try_policy()
 flush_nft_if_dirty_v4()
 {
     # Flush nftables v4 only if we selected legacy for v4 AND nft tables actually carry rules
-    if [ "${IPT}" = "iptables-legacy" ] && command -v iptables-nft >/dev/null 2>&1; then
+    if [ "${_IPT}" = "iptables-legacy" ] && command -v iptables-nft >/dev/null 2>&1; then
         if iptables-nft -S 2>/dev/null | grep -q '^-A ' || iptables-nft -t nat -S 2>/dev/null | grep -q '^-A '; then
             iptables-nft -F 2>/dev/null || true
             iptables-nft -t nat -F 2>/dev/null || true
@@ -46,7 +46,7 @@ flush_nft_if_dirty_v4()
 flush_nft_if_dirty_v6()
 {
     # Flush nftables v6 only if we selected legacy for v6 AND nft v6 tables actually carry rules
-    if [ -n "${IP6T:-}" ] && [ "${IP6T}" = "ip6tables-legacy" ] && command -v ip6tables-nft >/dev/null 2>&1; then
+    if [ -n "${_IP6T:-}" ] && [ "${_IP6T}" = "ip6tables-legacy" ] && command -v ip6tables-nft >/dev/null 2>&1; then
         if ip6tables-nft -S 2>/dev/null | grep -q '^-A ' || ip6tables-nft -t nat -S 2>/dev/null | grep -q '^-A '; then
             ip6tables-nft -F 2>/dev/null || true
             ip6tables-nft -t nat -F 2>/dev/null || true
@@ -60,49 +60,49 @@ flush_nft_if_dirty_v6()
 
 pick_ipv4_backend()
 {
-    IPT=""
+    _IPT=""
     if kernel_ge_4_18; then
         if command -v iptables >/dev/null 2>&1 && iptables -V 2>&1 | grep -qi "(nf_tables)"; then
-            try_policy iptables && IPT="iptables"
+            try_policy iptables && _IPT="iptables"
         fi
-        [ -n "$IPT" ] || { command -v iptables-legacy >/dev/null 2>&1 && try_policy iptables-legacy && IPT="iptables-legacy"; }
-        [ -n "$IPT" ] || { command -v iptables >/dev/null 2>&1 && try_policy iptables && IPT="iptables"; }
+        [ -n "$_IPT" ] || { command -v iptables-legacy >/dev/null 2>&1 && try_policy iptables-legacy && _IPT="iptables-legacy"; }
+        [ -n "$_IPT" ] || { command -v iptables >/dev/null 2>&1 && try_policy iptables && _IPT="iptables"; }
     else
         if command -v iptables-legacy >/dev/null 2>&1; then
-            try_policy iptables-legacy && IPT="iptables-legacy"
+            try_policy iptables-legacy && _IPT="iptables-legacy"
         fi
-        [ -n "$IPT" ] || { command -v iptables >/dev/null 2>&1 && try_policy iptables && IPT="iptables"; }
+        [ -n "$_IPT" ] || { command -v iptables >/dev/null 2>&1 && try_policy iptables && _IPT="iptables"; }
     fi
-    [ -n "$IPT" ] || { echo "[ENTRYPOINT] ERROR: no working iptables (IPv4) found"; exit 1; }
+    [ -n "$_IPT" ] || { echo "[ENTRYPOINT] ERROR: no working iptables (IPv4) found"; exit 1; }
 
     echo "[ENTRYPOINT] Kernel: $(uname -r)"
-    echo "[ENTRYPOINT] Using IPv4 backend: ${IPT}"
+    echo "[ENTRYPOINT] Using IPv4 backend: ${_IPT}"
 }
 
 # ---- IPv6 backend picker: prefer nft on ≥4.18; else legacy -----------------
 
 pick_ipv6_backend()
 {
-    IP6T=""
+    _IP6T=""
     if kernel_ge_4_18; then
         if command -v ip6tables >/dev/null 2>&1 && ip6tables -V 2>&1 | grep -qi "(nf_tables)"; then
-            try_policy ip6tables && IP6T="ip6tables"
+            try_policy ip6tables && _IP6T="ip6tables"
         fi
-        [ -n "$IP6T" ] || { command -v ip6tables-legacy >/dev/null 2>&1 && try_policy ip6tables-legacy && IP6T="ip6tables-legacy"; } || true
-        [ -n "$IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && try_policy ip6tables && IP6T="ip6tables"; } || true
+        [ -n "$_IP6T" ] || { command -v ip6tables-legacy >/dev/null 2>&1 && try_policy ip6tables-legacy && _IP6T="ip6tables-legacy"; } || true
+        [ -n "$_IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && try_policy ip6tables && _IP6T="ip6tables"; } || true
     else
         if command -v ip6tables-legacy >/dev/null 2>&1; then
-            try_policy ip6tables-legacy && IP6T="ip6tables-legacy"
+            try_policy ip6tables-legacy && _IP6T="ip6tables-legacy"
         fi
-        [ -n "$IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && try_policy ip6tables && IP6T="ip6tables"; } || true
+        [ -n "$_IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && try_policy ip6tables && _IP6T="ip6tables"; } || true
     fi
 
     # Last-resort: if a binary exists at all, use it (even if probe failed)
-    [ -n "$IP6T" ] || { command -v ip6tables-legacy >/dev/null 2>&1 && IP6T="ip6tables-legacy"; } || true
-    [ -n "$IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && IP6T="ip6tables"; } || true
+    [ -n "$_IP6T" ] || { command -v ip6tables-legacy >/dev/null 2>&1 && _IP6T="ip6tables-legacy"; } || true
+    [ -n "$_IP6T" ] || { command -v ip6tables >/dev/null 2>&1 && _IP6T="ip6tables"; } || true
 
-    if [ -n "$IP6T" ]; then
-        echo "[ENTRYPOINT] Using IPv6 backend: ${IP6T}"
+    if [ -n "$_IP6T" ]; then
+        echo "[ENTRYPOINT] Using IPv6 backend: ${_IP6T}"
     else
         echo "[ENTRYPOINT] IPv6 backend unavailable (disabled or not installed)"
     fi
@@ -111,10 +111,10 @@ pick_ipv6_backend()
 verify_ipv6_backend()
 {
     # If we picked something for v6, make sure v6 tables actually exist.
-    if [ -n "$IP6T" ]; then
-        if ! ${IP6T} -t filter -S >/dev/null 2>&1; then
+    if [ -n "$_IP6T" ]; then
+        if ! ${_IP6T} -t filter -S >/dev/null 2>&1; then
             echo "[ENTRYPOINT] IPv6 tables unavailable in this namespace; skipping IPv6 rules"
-            IP6T=""
+            _IP6T=""
         fi
     fi
 }
@@ -127,27 +127,15 @@ verify_ipv6_backend
 flush_nft_if_dirty_v4
 flush_nft_if_dirty_v6
 
-# After picking backends
-export IPT
-export IP6T
-
 # Publish for other scripts
 mkdir -p /run/xt
 {
-    printf 'IPT=%s\n' "$IPT"
-    printf 'IP6T=%s\n' "$IP6T"
+    printf 'IPT=%s\n' "$_IPT"
+    printf 'IP6T=%s\n' "$_IP6T"
 } > /run/xt/backend.env
 chmod 0644 /run/xt/backend.env
 
-run4() { if ! ${IPT} "$@" 2>/dev/null; then echo "[ENTRYPOINT] (IPv4) skipped: $*"; fi; }
-run6()
-{
-    if [ -n "$IP6T" ]; then
-        if ! ${IP6T} "$@" 2>/dev/null; then
-            echo "[ENTRYPOINT] (IPv6) skipped: $*"
-        fi
-    fi
-}
+. /usr/local/bin/backend_functions
 
 # ---- secure defaults (v4 + v6 if available) --------------------------------
 

--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -30,17 +30,10 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-# Reuse backend selected by entrypoint
-[ -r /run/xt/backend.env ] && . /run/xt/backend.env
+. /usr/local/bin/backend_functions
 
 # ---- Tool discovery ---------------------------------------------------------
-CURL_BIN="$(command -v curl 2>/dev/null || printf '')"
-JQ_BIN="$(command -v jq 2>/dev/null || printf '')"
-DIG_BIN="$(command -v dig 2>/dev/null || printf '')"
-RESOLVECTL_BIN="$(command -v resolvectl 2>/dev/null || printf '')"
 NFT_BIN="$(command -v nft 2>/dev/null || printf '')"
-IPT_BIN="$(command -v $IPT 2>/dev/null || printf '')"
-IP6T_BIN="$(command -v $IP6T 2>/dev/null || printf '')"
 TR_BIN="$(command -v traceroute 2>/dev/null || printf '')"
 [ -n "$TR_BIN" ] || TR_BIN="$(command -v tracepath 2>/dev/null || printf '')"
 
@@ -48,24 +41,16 @@ TR_BIN="$(command -v traceroute 2>/dev/null || printf '')"
 fetch_public_info()
 {
     IP=""; CITY=""; CC=""
-    if [ -n "$CURL_BIN" ]; then
-        RESP="$($CURL_BIN -s --max-time 4 https://ipinfo.io/json 2>/dev/null || printf '')"
-        if [ -n "$RESP" ]; then
-            if [ -n "$JQ_BIN" ]; then
-                IP="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.ip // empty' 2>/dev/null || printf '')"
-                CITY="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.city // empty' 2>/dev/null || printf '')"
-                CC="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.country // empty' 2>/dev/null || printf '')"
-            else
-                IP="$(printf "%s" "$RESP" | sed -n 's/.*"ip"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-                CITY="$(printf "%s" "$RESP" | sed -n 's/.*"city"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-                CC="$(printf "%s" "$RESP" | sed -n 's/.*"country"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-            fi
-        fi
-        if [ -z "$IP" ]; then
-            IP="$($CURL_BIN -s --max-time 4 https://ifconfig.co 2>/dev/null || printf '')"
-            CITY="$($CURL_BIN -s --max-time 4 https://ifconfig.co/city 2>/dev/null || printf '')"
-            CC="$($CURL_BIN -s --max-time 4 https://ifconfig.co/country-iso 2>/dev/null || printf '')"
-        fi
+    RESP="$(curl -s --max-time 4 https://ipinfo.io/json 2>/dev/null || printf '')"
+    if [ -n "$RESP" ]; then
+        IP="$(printf "%s" "$RESP" | jq -r '.ip // empty' 2>/dev/null || printf '')"
+        CITY="$(printf "%s" "$RESP" | jq -r '.city // empty' 2>/dev/null || printf '')"
+        CC="$(printf "%s" "$RESP" | jq -r '.country // empty' 2>/dev/null || printf '')"
+    fi
+    if [ -z "$IP" ]; then
+        IP="$(curl -s --max-time 4 https://ifconfig.co 2>/dev/null || printf '')"
+        CITY="$(curl -s --max-time 4 https://ifconfig.co/city 2>/dev/null || printf '')"
+        CC="$(curl -s --max-time 4 https://ifconfig.co/country-iso 2>/dev/null || printf '')"
     fi
 }
 
@@ -103,38 +88,21 @@ ns_geo_line()
         echo "$IPQ : (private/local resolver)"
         return
     fi
-    if [ -z "$CURL_BIN" ]; then
-        echo "$IPQ : (curl not available)"
-        return
-    fi
 
     CITY=""; CC=""; ORG=""
-    RESP="$($CURL_BIN -s --max-time 4 "https://ipinfo.io/$IPQ/json" 2>/dev/null || printf '')"
+    RESP="$(curl -s --max-time 4 "https://ipinfo.io/$IPQ/json" 2>/dev/null || printf '')"
     if [ -n "$RESP" ]; then
-        if [ -n "$JQ_BIN" ]; then
-            CITY="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.city // empty' 2>/dev/null || printf '')"
-            CC="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.country // empty' 2>/dev/null || printf '')"
-            ORG="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.org // empty' 2>/dev/null || printf '')"
-        else
-            CITY="$(printf "%s" "$RESP" | sed -n 's/.*"city"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-            CC="$(printf "%s" "$RESP" | sed -n 's/.*"country"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-            ORG="$(printf "%s" "$RESP" | sed -n 's/.*"org"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-        fi
+        CITY="$(printf "%s" "$RESP" | jq -r '.city // empty' 2>/dev/null || printf '')"
+        CC="$(printf "%s" "$RESP" | jq -r '.country // empty' 2>/dev/null || printf '')"
+        ORG="$(printf "%s" "$RESP" | jq -r '.org // empty' 2>/dev/null || printf '')"
     fi
     if [ -z "$CITY$CC$ORG" ]; then
-        RESP="$($CURL_BIN -s --max-time 4 "https://ipapi.co/$IPQ/json/" 2>/dev/null || printf '')"
+        RESP="$(curl -s --max-time 4 "https://ipapi.co/$IPQ/json/" 2>/dev/null || printf '')"
         if [ -n "$RESP" ]; then
-            if [ -n "$JQ_BIN" ]; then
-                CITY="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.city // empty' 2>/dev/null || printf '')"
-                CC="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.country // empty' 2>/dev/null || printf '')"
-                [ -n "$CC" ] || CC="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.country_code // empty' 2>/dev/null || printf '')"
-                ORG="$(printf "%s" "$RESP" | "$JQ_BIN" -r '.org // empty' 2>/dev/null || printf '')"
-            else
-                CITY="$(printf "%s" "$RESP" | sed -n 's/.*"city"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-                CC="$(printf "%s" "$RESP" | sed -n 's/.*"country_code"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-                [ -n "$CC" ] || CC="$(printf "%s" "$RESP" | sed -n 's/.*"country"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-                ORG="$(printf "%s" "$RESP" | sed -n 's/.*"org"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1)"
-            fi
+                CITY="$(printf "%s" "$RESP" | jq -r '.city // empty' 2>/dev/null || printf '')"
+                CC="$(printf "%s" "$RESP" | jq -r '.country // empty' 2>/dev/null || printf '')"
+                [ -n "$CC" ] || CC="$(printf "%s" "$RESP" | jq -r '.country_code // empty' 2>/dev/null || printf '')"
+                ORG="$(printf "%s" "$RESP" | jq -r '.org // empty' 2>/dev/null || printf '')"
         fi
     fi
     [ -n "$CITY" ] || CITY="Unknown"
@@ -157,8 +125,8 @@ print_dns_geo()
 {
     echo "### DNS servers geolocation"
     NS_LIST="$(awk '/^nameserver/ {print $2}' /etc/resolv.conf 2>/dev/null | sed 's/%.*//' | sort -u)"
-    if [ -z "$NS_LIST" ] && [ -n "$RESOLVECTL_BIN" ]; then
-        NS_LIST="$($RESOLVECTL_BIN dns 2>/dev/null | tr ' ' '\n' | sed 's/%.*//' | \
+    if [ -z "$NS_LIST" ]; then
+        NS_LIST="$(resolvectl dns 2>/dev/null | tr ' ' '\n' | sed 's/%.*//' | \
             grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$|^[0-9a-fA-F:]+$' | sort -u)"
     fi
     if [ -z "$NS_LIST" ]; then
@@ -250,83 +218,67 @@ else
     echo "[info] nft not present"
 fi
 
-if [ -n "$IPT_BIN" ]; then
-    echo
-    echo "### iptables -S (filter)"
-    "$IPT_BIN" -S 2>/dev/null || true
+echo
+echo "### iptables -S (filter)"
+run4 -S 2>/dev/null || true
 
-    echo
-    echo "### iptables -t nat -S (IPv4 NAT)"
-    "$IPT_BIN" -t nat -S 2>/dev/null || echo "(no IPv4 NAT rules or table unavailable)"
+echo
+echo "### iptables -t nat -S (IPv4 NAT)"
+run4 -t nat -S 2>/dev/null || echo "(no IPv4 NAT rules or table unavailable)"
 
-    # Optional counters view (comment out if too verbose)
-    # echo
-    # echo "### iptables -t nat -L -n -v (counters)"
-    # "$IPT_BIN" -t nat -L -n -v 2>/dev/null || true
-fi
+# Optional counters view (comment out if too verbose)
+# echo
+# echo "### iptables -t nat -L -n -v (counters)"
+# "$IPT" -t nat -L -n -v 2>/dev/null || true
 
 if [ -n "${IP6T}" ]; then
     echo
     echo "### ip6tables -S (filter)"
-    "$IP6T_BIN" -S 2>/dev/null || true
+    run6 -S 2>/dev/null || true
 
     echo
     echo "### ip6tables -t nat -S (IPv6 NAT)"
-    "$IP6T_BIN" -t nat -S 2>/dev/null || echo "(no IPv6 NAT rules or table unavailable)"
+    run6 -t nat -S 2>/dev/null || echo "(no IPv6 NAT rules or table unavailable)"
 fi
 echo
 
 # Public IP & rough geo (JSON from same provider as summary)
 echo "### Public IP / Geo (best-effort)"
-if [ -n "$CURL_BIN" ]; then
-    RESP="$($CURL_BIN -s --max-time 4 https://ipinfo.io/json 2>/dev/null || printf '')"
-    if [ -z "$RESP" ]; then
-        RESP="$($CURL_BIN -s --max-time 4 https://ifconfig.co/json 2>/dev/null || printf '')"
-    fi
-    if [ -n "$RESP" ]; then
-        if [ -n "$JQ_BIN" ]; then
-            echo "$RESP" | "$JQ_BIN" . 2>/dev/null || echo "$RESP"
-        else
-            echo "$RESP"
-        fi
-    else
-        echo "[warn] could not fetch public info"
-    fi
+RESP="$(curl -s --max-time 4 https://ipinfo.io/json 2>/dev/null || printf '')"
+if [ -z "$RESP" ]; then
+    RESP="$(curl -s --max-time 4 https://ifconfig.co/json 2>/dev/null || printf '')"
+fi
+if [ -n "$RESP" ]; then
+    echo "$RESP" | jq . 2>/dev/null || echo "$RESP"
 else
-    echo "[warn] curl not available"
+    echo "[warn] could not fetch public info"
 fi
 echo
 
 # DNS configuration & identity probe
 echo "### DNS configuration"
-if [ -n "$RESOLVECTL_BIN" ]; then
-    "$RESOLVECTL_BIN" status "$DEV_IF" 2>/dev/null || "$RESOLVECTL_BIN" status 2>/dev/null || true
-else
-    cat /etc/resolv.conf 2>/dev/null || true
-fi
+resolvectl status "$DEV_IF" 2>/dev/null || resolvectl status 2>/dev/null || true
 echo
 
 print_dns_geo
 
 # Resolver identity (with fallbacks)
-if [ -n "$DIG_BIN" ]; then
-    NS_ACTIVE="$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf 2>/dev/null)"
-    if [ -n "$NS_ACTIVE" ]; then
-        echo "### resolver identity via $NS_ACTIVE"
-        OUT="$("$DIG_BIN" +timeout=3 +short TXT whoami.cloudflare @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
-        if [ -z "$OUT" ]; then
-            OUT="$("$DIG_BIN" +timeout=3 +short CHAOS TXT id.server @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
-        fi
-        if [ -z "$OUT" ]; then
-            OUT="$("$DIG_BIN" +timeout=3 +short CHAOS TXT hostname.bind @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
-        fi
-        if [ -n "$OUT" ]; then
-            echo "$OUT"
-        else
-            echo "(no identity TXT available from resolver)"
-        fi
-        echo
+NS_ACTIVE="$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf 2>/dev/null)"
+if [ -n "$NS_ACTIVE" ]; then
+    echo "### resolver identity via $NS_ACTIVE"
+    OUT="$(dig +timeout=3 +short TXT whoami.cloudflare @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
+    if [ -z "$OUT" ]; then
+        OUT="$(dig +timeout=3 +short CHAOS TXT id.server @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
     fi
+    if [ -z "$OUT" ]; then
+        OUT="$(dig +timeout=3 +short CHAOS TXT hostname.bind @"$NS_ACTIVE" 2>/dev/null | sed -n '1p')"
+    fi
+    if [ -n "$OUT" ]; then
+        echo "$OUT"
+    else
+        echo "(no identity TXT available from resolver)"
+    fi
+    echo
 fi
 
 # Connectivity probes


### PR DESCRIPTION
This PR refactors the iptables backend selection logic to eliminate code duplication across multiple scripts. Key changes include:

- New shared module: Created `backend_functions` script containing common backend detection and helper functions (`run4`, `run6`).
- Entrypoint updates: Export the selected backends to `/run/xt/backend.env`.
- Script consolidation: Updated `init-firewall/run`, `nordvpnd/run`, and `network-diagnostic` to source `backend_functions` instead of duplicating backend logic.
- Cleanup: Removed redundant tool availability checks in `network-diagnostic`, assuming standard tools are present.

This improves maintainability by centralizing backend selection logic and reduces the risk of inconsistencies between scripts. All changes preserve existing functionality and error handling.