### PR TITLE
Sort NordVPN API IPs in maintenance workflow

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -318,7 +318,7 @@ jobs:
         run: |
           echo "Fetching countries data from NordVPN API..."
 
-          IPS=$(dig +short A api.nordvpn.com | tr '\n' ';' | sed 's/;$//')
+          IPS=$(dig +short A api.nordvpn.com | sort -V | tr '\n' ';' | sed 's/;$//')
           sed -i "s/^\(\s*\)NORDVPNAPI_IP=.*/\1NORDVPNAPI_IP=${IPS} \\\/" Dockerfile
 
           UPDATE_DATE=$(date +%y%m%d)


### PR DESCRIPTION
This PR modifies the maintenance workflow to sort the IP addresses retrieved from `api.nordvpn.com` before setting them in the `NORDVPNAPI_IP` environment variable in the Dockerfile.

Changes:

- Added `sort -V` to the command pipeline in `maintenance-updates.yml` to ensure IP addresses are sorted in version order.


Reason: Sorting the IPs provides consistent ordering, preventing unnecessary diffs in the Dockerfile due to random IP sequence variations from the DNS lookup. This improves reproducibility and reduces noise in automated updates.