### PR TITLE
Add named iptables chain for VPN server rules

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -8,8 +8,6 @@ echo "[INIT-FIREWALL] Setting up firewall - everything has to go through the VPN
 
 . /usr/local/bin/backend-functions
 
-add4() { if ! $IPT "$@" 2>/dev/null; then echo "[INIT-FIREWALL] (IPv4) skipped: $*"; fi; }
-
 # BusyBox-friendly helpers
 docker_network="$(ip addr show dev eth0 2>/dev/null | awk '/inet / {print $2; exit}')"
 gw="$(ip route 2>/dev/null | awk '/default/ {print $3; exit}')"
@@ -19,12 +17,17 @@ if [ -n "$docker_network" ]; then
     echo "[INIT-FIREWALL] IPv4 rules..."
 
     # Stateful fast-path (skip gracefully if conntrack match absent)
-    add4 -A INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-    add4 -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+    run4 -A INPUT  -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+    run4 -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
     # Allow outbound to VPN interfaces + NAT
-    add4 -A OUTPUT -o tun+ -j ACCEPT
-    add4 -t nat -A POSTROUTING -o tun+ -j MASQUERADE
+    run4 -A OUTPUT -o tun+ -j ACCEPT
+    run4 -t nat -A POSTROUTING -o tun+ -j MASQUERADE
+
+    # Create named chain for VPN Server rules
+    run4 -N VPN-SERVER
+    run4 -A OUTPUT -p udp --dport 1194 -j VPN-SERVER
+    run4 -A OUTPUT -p tcp --dport 443 -j VPN-SERVER
 
     # NordVPN API bootstrap (TCP/443) by resolved IPs
     if [ -n "$NORDVPNAPI_IP" ]; then
@@ -32,7 +35,7 @@ if [ -n "$docker_network" ]; then
         oldIFS="$IFS"; IFS=',;'
         for ip in $NORDVPNAPI_IP; do
             [ -z "$ip" ] && continue
-            add4 -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
+            run4 -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
         done
         IFS="$oldIFS"
     fi
@@ -48,7 +51,7 @@ if [ -n "$docker_network" ]; then
                 ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev eth0 2>/dev/null || true
             fi
             # Allow inbound from this network only
-            add4 -A INPUT -i eth0 -s "$net" -j ACCEPT
+            run4 -A INPUT -i eth0 -s "$net" -j ACCEPT
         done
         IFS="$oldIFS"
     fi

--- a/root/etc/s6-overlay/s6-rc.d/nordvpnd/run
+++ b/root/etc/s6-overlay/s6-rc.d/nordvpnd/run
@@ -53,17 +53,16 @@ r_proto="$(normalize_proto "$r_proto_raw")"
 r_ip="$(echo "$r_ip_raw" | sed 's,^\[,,' | sed 's,\]$,,' )"
 
 # -------- add a single temporary pinhole on eth0 --------
-PIN_SPEC="OUTPUT -o eth0 -p ${r_proto} -d ${r_ip} --dport ${r_port} -j ACCEPT"
-if ! $IPT -C $PIN_SPEC 2>/dev/null; then
-    $IPT -I $PIN_SPEC
-    echo "[SERVICE-NORDVPND] pinhole added: $IPT -I $PIN_SPEC"
-else
-    echo "[SERVICE-NORDVPND] pinhole already present"
+
+run4 -F VPN-SERVER
+PIN_SPEC="-A VPN-SERVER -o eth0 -p ${r_proto} -d ${r_ip} --dport ${r_port} -j ACCEPT"
+if run4 $PIN_SPEC 2>/dev/null; then
+    echo "[SERVICE-NORDVPND] pinhole added: $IPT $PIN_SPEC"
 fi
 
 cleanup() {
     echo "[SERVICE-NORDVPND] Cleaning VPN pinhole..."
-    $IPT -D $PIN_SPEC 2>/dev/null || true
+    run4 -F VPN-SERVER
 }
 
 # -------- run OpenVPN --------

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -6,14 +6,14 @@
 
 run4() {
     if ! ${IPT} "$@" 2>/dev/null; then
-        echo "[ENTRYPOINT] (IPv4) skipped: $*"
+        echo "(IPv4) skipped: $*"
     fi
 }
 
 run6() {
     if [ -n "$IP6T" ]; then
         if ! ${IP6T} "$@" 2>/dev/null; then
-            echo "[ENTRYPOINT] (IPv6) skipped: $*"
+            echo "(IPv6) skipped: $*"
         fi
     fi
 }


### PR DESCRIPTION
This PR introduces a named iptables chain `VPN-SERVER` to better organize and manage firewall rules related to VPN server connections. The changes improve rule management by centralizing VPN-specific rules into a dedicated chain, making it easier to add, remove, and flush rules without affecting other firewall configurations.

#### Changes Made
- **Firewall Initialization (`init-firewall/run`)**:
  - Replaced the `add4` helper function with `run4` for consistency.
  - Created a new named chain `VPN-SERVER` for VPN-related rules.
  - Added rules to jump to `VPN-SERVER` for OpenVPN ports (UDP 1194 and TCP 443).
  - Updated NordVPN API and network-specific rules to use `run4`.

- **NordVPN Service (`nordvpnd/run`)**:
  - Refactored pinhole creation to add rules to the `VPN-SERVER` chain instead of directly to the `OUTPUT` chain.
  - Updated cleanup to flush the entire `VPN-SERVER` chain, simplifying rule management.

- **Backend Functions (`backend-functions`)**:
  - Simplified log messages by removing the `[ENTRYPOINT]` prefix for cleaner output.

#### Benefits
- **Improved Maintainability**: Centralized VPN rules in a named chain allow for easier debugging and modifications.
- **Better Rule Isolation**: Flushing the `VPN-SERVER` chain clears all VPN-related rules without impacting other firewall rules.
- **Consistency**: Unified use of `run4` helper function across firewall scripts.

#### Testing
- Verified that the iptables rules are applied correctly during container startup.
- Confirmed that VPN connections work as expected with the new chain structure.
- Ensured backward compatibility with existing configurations.
