### PR TITLE
feat: add force update option to workflow dispatch

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -26,6 +26,11 @@ on:
           - nordvpn-api-ips
           - packages
           - apk
+      force_update:
+        description: 'Force update MD files even if content unchanged'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   update-readme-files:
@@ -79,8 +84,8 @@ jobs:
             EXISTING_CONTENT=""
           fi
           
-          # Compare
-          if [ "$NEW_CONTENT" != "$EXISTING_CONTENT" ]; then
+          # Check force update or compare
+          if [ "${{ github.event.inputs.force_update }}" == "true" ] || [ "$NEW_CONTENT" != "$EXISTING_CONTENT" ]; then
             echo "$NEW_CONTENT" > "${{ matrix.file.name }}.md"
             echo "---" >> "${{ matrix.file.name }}.md"
             echo "Last updated: $(date +%Y-%m-%d)" >> "${{ matrix.file.name }}.md"


### PR DESCRIPTION
Add a 'force_update' boolean input to the workflow dispatch that allows forcing updates of README MD files even when content hasn't changed.

## Changes:
- Added `force_update` boolean input (default: false) to workflow_dispatch
- Modified update-readme-files job to check force_update flag
- Combined duplicate if/elif logic into single OR condition
- Maintains backward compatibility with existing behavior

## Usage:
When manually triggering the workflow, check 'Force update MD files even if content unchanged' to force regeneration of all README files with fresh timestamps, regardless of API data changes.