### PR TITLE
Fix script name in network-diagnostic and update firewall rules

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -21,8 +21,8 @@ if [ -n "$docker_network" ]; then
     run4_critical -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
     # Allow outbound to VPN interfaces + NAT
-    run4_critical -A OUTPUT -o tun+ -j ACCEPT
-    run4_critical -t nat -A POSTROUTING -o tun+ -j MASQUERADE
+    run4_critical -A OUTPUT -o tun0 -j ACCEPT
+    run4_critical -t nat -A POSTROUTING -o tun0 -j MASQUERADE
 
     # Create named chain for VPN Server rules
     run4 -N VPN-SERVER

--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -1,6 +1,6 @@
 #!/bin/sh
-# vpn-diag: POSIX sh network diagnostics for an OpenVPN-connected system (Docker-friendly)
-# Usage: vpn-diag [--basic|-b] | [--full|-f] | [--help|-h]
+# network-diagnostic: POSIX sh network diagnostics for an OpenVPN-connected system (Docker-friendly)
+# Usage: network-diagnostic [--basic|-b] | [--full|-f] | [--help|-h]
 # Default mode is --full.
 
 set -u  # be strict about undefined vars
@@ -10,7 +10,7 @@ MODE="full"
 print_usage()
 {
     cat <<'EOF'
-Usage: vpn-diag [options]
+Usage: network-diagnostic [options]
 
 Options:
     -b, --basic   Print only: "Public IP address X.X.X.X, location City CC"


### PR DESCRIPTION
This PR fixes the script name references in network-diagnostic and updates firewall rules for more specific interface matching.

Changes:
- Update network-diagnostic script comments and usage to use correct script name
- Change firewall rules from tun+ to tun0 for more specific interface matching