### PR TITLE
Fix table of contents link for IPv6 behavior section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OpenVPN client docker container that routes other containers' traffic through No
   - [Getting Service Credentials](#getting-service-credentials)
 - [Configuration Options](#configuration-options)
   - [Server Selection](#server-selection)
-  - [IPv6 behavior](#ipv6-behavior-read-this)
+  - [IPv6 behavior](#ipv6-behavior)
   - [Automatic Reconnection](#automatic-reconnection)
     - [Scheduled Reconnection](#scheduled-reconnection)
     - [Connection Failure Handling](#connection-failure-handling)


### PR DESCRIPTION
The table of contents had an incorrect link for the IPv6 behavior section. Fixed the anchor link to match the actual heading ID.