### PR TITLE
fix: remove condition for APK PR creation

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -392,7 +392,6 @@ jobs:
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request for APK updates
-        if: steps.update-apk.outputs.has_updates == 'true'
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           branch: bot/update-apk-packages


### PR DESCRIPTION
Remove the 'if' condition that prevented creating PR for APK updates when no updates were found. Now PR will be created regardless.

This ensures that the APK update job always attempts to create a PR, even if no packages were updated, which can be useful for tracking the workflow runs.