### PR TITLE
fix: parse APK update script output for proper PR creation

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -385,13 +385,34 @@ jobs:
         id: update-apk
         run: |
           chmod +x ./scripts/update-apk-versions.sh
-          ./scripts/update-apk-versions.sh Dockerfile
-
+          OUTPUT=$(./scripts/update-apk-versions.sh Dockerfile 2>&1)
+          echo "$OUTPUT"
+          
           UPDATE_DATE=$(date +%y%m%d)
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_ENV
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_OUTPUT
+          
+          # Parse the output to extract summary information
+          TOTAL_PACKAGES=$(echo "$OUTPUT" | grep "Total packages checked:" | sed 's/.*: //' | tr -d '\n')
+          UPDATED_COUNT=$(echo "$OUTPUT" | grep "Packages updated:" | sed 's/.*: //' | tr -d '\n')
+          
+          # Extract updated packages list
+          PACKAGES_UPDATED=$(echo "$OUTPUT" | sed -n '/Updated packages:/,/^$/p' | tail -n +2 | sed '/^$/d' | sed 's/^/- /')
+          if [ -z "$PACKAGES_UPDATED" ]; then
+            PACKAGES_UPDATED="No packages needed updates"
+          fi
+          
+          echo "total_packages=$TOTAL_PACKAGES" >> $GITHUB_OUTPUT
+          echo "updated_count=$UPDATED_COUNT" >> $GITHUB_OUTPUT
+          echo "packages_updated<<EOF" >> $GITHUB_OUTPUT
+          echo "$PACKAGES_UPDATED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          HAS_UPDATES=$([ "$UPDATED_COUNT" -gt 0 ] && echo "true" || echo "false")
+          echo "has_updates=$HAS_UPDATES" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request for APK updates
+        if: steps.update-apk.outputs.has_updates == 'true'
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           branch: bot/update-apk-packages


### PR DESCRIPTION
Fix the APK package update workflow to properly parse the script output and create PRs with correct information.

**Changes:**
- Capture the output of the update-apk-versions.sh script
- Parse the summary section to extract total packages checked, updated count, and list of updated packages
- Set proper GITHUB_OUTPUT variables for use in PR creation
- Restore the condition to only create PR when packages are actually updated
- Ensure PR body includes detailed list of updated packages with version changes

This resolves the issue where PRs were created with '0 of 0 checked' and missing package update details.