### PR TITLE
fix: correct package counting in APK update script

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -385,13 +385,34 @@ jobs:
         id: update-apk
         run: |
           chmod +x ./scripts/update-apk-versions.sh
-          ./scripts/update-apk-versions.sh Dockerfile
-
+          OUTPUT=$(./scripts/update-apk-versions.sh Dockerfile 2>&1)
+          echo "$OUTPUT"
+          
           UPDATE_DATE=$(date +%y%m%d)
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_ENV
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_OUTPUT
+          
+          # Parse the output to extract summary information
+          TOTAL_PACKAGES=$(echo "$OUTPUT" | grep "Total packages checked:" | sed 's/.*: //' | tr -d '\n')
+          UPDATED_COUNT=$(echo "$OUTPUT" | grep "Packages updated:" | sed 's/.*: //' | tr -d '\n')
+          
+          # Extract updated packages list
+          PACKAGES_UPDATED=$(echo "$OUTPUT" | sed -n '/Updated packages:/,/^$/p' | tail -n +2 | sed '/^$/d' | sed 's/^/- /')
+          if [ -z "$PACKAGES_UPDATED" ]; then
+            PACKAGES_UPDATED="No packages needed updates"
+          fi
+          
+          echo "total_packages=$TOTAL_PACKAGES" >> $GITHUB_OUTPUT
+          echo "updated_count=$UPDATED_COUNT" >> $GITHUB_OUTPUT
+          echo "packages_updated<<EOF" >> $GITHUB_OUTPUT
+          echo "$PACKAGES_UPDATED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          HAS_UPDATES=$([ "$UPDATED_COUNT" -gt 0 ] && echo "true" || echo "false")
+          echo "has_updates=$HAS_UPDATES" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request for APK updates
+        if: steps.update-apk.outputs.has_updates == 'true'
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           branch: bot/update-apk-packages

--- a/scripts/update-apk-versions.sh
+++ b/scripts/update-apk-versions.sh
@@ -100,9 +100,12 @@ update_package_with_tracking() {
 }
 
 # --- 6. Loop Over All Packages and Update ---
-echo "$packages" | while IFS= read -r package; do
+IFS='
+'
+for package in $packages; do
     update_package_with_tracking "$package"
 done
+unset IFS
 
 # --- 7. Output summary ---
 echo "=== UPDATE SUMMARY ==="


### PR DESCRIPTION
Fix the APK package update script to properly count total packages checked and packages updated.

**Issue:** The script was using a piped while loop which runs in a subshell, preventing TOTAL_PACKAGES and UPDATED_COUNT variables from being updated in the main shell. This caused the summary to always show 0 packages checked and 0 updated, even when packages were actually processed.

**Fix:** Changed the loop from:


To:


This ensures the variables are updated in the main shell scope.

**Result:** The script now correctly reports the number of packages checked and updated in the summary output.