### PR TITLE
fix: correct package counting in APK update script

### DIFF
--- a/scripts/update-apk-versions.sh
+++ b/scripts/update-apk-versions.sh
@@ -100,9 +100,12 @@ update_package_with_tracking() {
 }
 
 # --- 6. Loop Over All Packages and Update ---
-echo "$packages" | while IFS= read -r package; do
+IFS='
+'
+for package in $packages; do
     update_package_with_tracking "$package"
 done
+unset IFS
 
 # --- 7. Output summary ---
 echo "=== UPDATE SUMMARY ==="


### PR DESCRIPTION
Fix the APK package update script to properly count total packages checked and packages updated.

**Issue:** The script was using a piped while loop which runs in a subshell, preventing TOTAL_PACKAGES and UPDATED_COUNT variables from being updated in the main shell. This caused the summary to always show 0 packages checked and 0 updated, even when packages were actually processed.

**Fix:** Changed the loop from:


To:


This ensures the variables are updated in the main shell scope.

**Result:** The script now correctly reports the number of packages checked and updated in the summary output.