### PR TITLE
refactor: simplify APK workflow to reuse script outputs

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -385,34 +385,13 @@ jobs:
         id: update-apk
         run: |
           chmod +x ./scripts/update-apk-versions.sh
-          OUTPUT=$(./scripts/update-apk-versions.sh Dockerfile 2>&1)
-          echo "$OUTPUT"
-          
+          ./scripts/update-apk-versions.sh Dockerfile
+
           UPDATE_DATE=$(date +%y%m%d)
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_ENV
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_OUTPUT
-          
-          # Parse the output to extract summary information
-          TOTAL_PACKAGES=$(echo "$OUTPUT" | grep "Total packages checked:" | sed 's/.*: //' | tr -d '\n')
-          UPDATED_COUNT=$(echo "$OUTPUT" | grep "Packages updated:" | sed 's/.*: //' | tr -d '\n')
-          
-          # Extract updated packages list
-          PACKAGES_UPDATED=$(echo "$OUTPUT" | sed -n '/Updated packages:/,/^$/p' | tail -n +2 | sed '/^$/d' | sed 's/^/- /')
-          if [ -z "$PACKAGES_UPDATED" ]; then
-            PACKAGES_UPDATED="No packages needed updates"
-          fi
-          
-          echo "total_packages=$TOTAL_PACKAGES" >> $GITHUB_OUTPUT
-          echo "updated_count=$UPDATED_COUNT" >> $GITHUB_OUTPUT
-          echo "packages_updated<<EOF" >> $GITHUB_OUTPUT
-          echo "$PACKAGES_UPDATED" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          
-          HAS_UPDATES=$([ "$UPDATED_COUNT" -gt 0 ] && echo "true" || echo "false")
-          echo "has_updates=$HAS_UPDATES" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request for APK updates
-        if: steps.update-apk.outputs.has_updates == 'true'
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           branch: bot/update-apk-packages


### PR DESCRIPTION
Simplify the APK package update workflow by removing manual output parsing and letting the script set GITHUB_OUTPUT directly.

**Changes:**
- Removed the complex output parsing logic from the workflow
- Simplified the update step to just run the script
- The script now sets all necessary outputs (total_packages, updated_count, packages_updated, has_updates) directly to GITHUB_OUTPUT
- Workflow uses these step outputs directly for PR creation
- Removed the condition for PR creation to always create PRs (for tracking purposes)

This makes the workflow cleaner and relies on the script's built-in output functionality.