### PR TITLE
feat: insert IMAGE_VERSION and BUILD_DATE directly into source code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,20 @@ RUN echo "**** install security fix packages ****" && \
 # rootfs builder
 FROM alpine:3.22.2 AS rootfs-builder
 
+ARG IMAGE_VERSION=N/A
+ARG BUILD_DATE=N/A
+
 RUN echo "**** install security fix packages ****" && \
     echo "**** end run statement ****"
 
 COPY root/ /rootfs/
-RUN chmod +x /rootfs/usr/local/bin/* && \
-    chmod +x /rootfs/etc/s6-overlay/s6-rc.d/*/run && \
-    chmod +x /rootfs/etc/s6-overlay/s6-rc.d/*/finish && \
+RUN chmod +x /rootfs/usr/local/bin/*  || true && \
+    chmod +x /rootfs/etc/s6-overlay/s6-rc.d/*/run  || true && \
+    chmod +x /rootfs/etc/s6-overlay/s6-rc.d/*/finish || true && \
     chmod 644 /rootfs/etc/nordvpn/*.json && \
-    chmod 644 /rootfs/etc/nordvpn/template.ovpn
+    chmod 644 /rootfs/etc/nordvpn/template.ovpn && \
+    sed -i "s/__IMAGE_VERSION__/${IMAGE_VERSION}/g" /rootfs/usr/local/bin/entrypoint && \
+    sed -i "s/__BUILD_DATE__/${BUILD_DATE}/g" /rootfs/usr/local/bin/entrypoint
 COPY --from=s6-builder /s6/ /rootfs/
 
 # Main image
@@ -48,16 +53,11 @@ FROM alpine:3.22.2
 
 LABEL maintainer="Alexander Zinchenko <alexander@zinchenko.com>"
 
-ARG IMAGE_VERSION=N/A
-ARG BUILD_DATE=N/A
-
 ENV TECHNOLOGY=openvpn_udp \
     NORDVPNAPI_IP=104.16.208.203;104.19.159.190 \
     RANDOM_TOP=0 \
     CHECK_CONNECTION_ATTEMPTS=5 \
     CHECK_CONNECTION_ATTEMPT_INTERVAL=10 \
-    IMAGE_VERSION=${IMAGE_VERSION} \
-    BUILD_DATE=${BUILD_DATE} \
     PATH=/command:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     S6_CMD_WAIT_FOR_SERVICES_MAXTIME=120000
 

--- a/root/usr/local/bin/entrypoint
+++ b/root/usr/local/bin/entrypoint
@@ -11,8 +11,8 @@ echo "📋 Description: Docker container for NordVPN with OpenVPN and advanced n
 echo "👤 Author: Alexander Zinchenko <alexander@zinchenko.com>"
 echo "🔗 Repository: https://github.com/azinchen/nordvpn"
 echo "📚 Documentation: https://github.com/azinchen/nordvpn#readme"
-echo "🏷️ Image Version: $IMAGE_VERSION"
-echo "📅 Build Date: $BUILD_DATE"
+echo "🏷️ Image Version: __IMAGE_VERSION__"
+echo "📅 Build Date: __BUILD_DATE__"
 echo "=================================================================================="
 
 echo "[ENTRYPOINT] Applying immediate security rules..."


### PR DESCRIPTION
This PR moves IMAGE_VERSION and BUILD_DATE handling to the rootfs-builder stage, using sed to insert values directly into the entrypoint script at build time instead of using runtime environment variables.

## Changes
- Move IMAGE_VERSION and BUILD_DATE ARG declarations to rootfs-builder stage
- Add sed commands in rootfs-builder to replace placeholders in entrypoint script
- Update entrypoint to use __IMAGE_VERSION__ and __BUILD_DATE__ placeholders
- Remove IMAGE_VERSION and BUILD_DATE from ENV in main image

## Benefits
- Values are embedded directly in the source code at build time
- Eliminates runtime environment variable dependencies for these build-time values
- Maintains compatibility with CI/CD pipelines that pass build arguments