### PR TITLE
🔧 Fix NORDVPNAPI_IP addresses and workflow update logic

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -343,10 +343,16 @@ jobs:
         id: nordvpn-api-ips
         shell: bash
         run: |
-          echo "Fetching countries data from NordVPN API..."
+          echo "Fetching NordVPN API addresses..."
 
           IPS=$(dig +short A api.nordvpn.com | sort -V | tr '\n' ';' | sed 's/;$//')
-          sed -i "s/nordvpnapi_ip=\"\${NORDVPNAPI_IP:-\([^\"]*\)}\"/nordvpnapi_ip=\"\${NORDVPNAPI_IP:-\${IPS}}\"/" root/usr/local/bin/backend-functions
+          echo "Found IPs: $IPS"
+          
+          # Escape special characters for sed
+          IPS_ESCAPED=$(echo "$IPS" | sed 's/[&/\]/\\&/g')
+          
+          # Update the backend-functions file with actual IP addresses
+          sed -i "s|nordvpnapi_ip=\"\${NORDVPNAPI_IP:-[^\"]*}\"|nordvpnapi_ip=\"\${NORDVPNAPI_IP:-${IPS_ESCAPED}}\"|" root/usr/local/bin/backend-functions
 
           UPDATE_DATE=$(date +%y%m%d)
           echo "update_date=${UPDATE_DATE}" >> $GITHUB_ENV

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -19,7 +19,7 @@ user="${USER:-}"
 pass="${PASS:-}"
 recreate_vpn_cron="${RECREATE_VPN_CRON:-}"
 check_connection_cron="${CHECK_CONNECTION_CRON:-}"
-nordvpnapi_ip="${NORDVPNAPI_IP:-${IPS}}"
+nordvpnapi_ip="${NORDVPNAPI_IP:-104.16.208.203;104.19.159.190}"
 network="${NETWORK:-}"
 
 # Common file paths


### PR DESCRIPTION
## Problem
The workflow was setting incorrect NordVPN API IP addresses in `backend-functions`. The file contained an undefined variable reference `${IPS}` instead of actual IP addresses, which would cause connection failures during VPN bootstrap.

## Changes
1. **Fixed `backend-functions`**: Updated `NORDVPNAPI_IP` default value from undefined `${IPS}` to actual IP addresses: `104.16.208.203;104.19.159.190`
2. **Fixed workflow**: Updated `.github/workflows/maintenance-updates.yml` to properly substitute actual IP addresses instead of keeping the variable reference
   - Added proper escaping for sed
   - Added debug output to show found IPs
   - Changed sed delimiter to pipe for better readability

## Testing
- Verified IPs with: `dig +short A api.nordvpn.com`
- Confirmed sed pattern now correctly replaces with actual IP values

## Impact
- VPN bootstrap will now work correctly with pinned IP addresses
- Future workflow runs will properly update IPs when they change