### PR TITLE
Fix empty DNS configuration section in network-diagnostic

### DIFF
--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -477,7 +477,12 @@ echo
 
 # DNS configuration & identity probe
 echo "### DNS configuration"
-resolvectl status "$DEV_IF" 2>/dev/null || resolvectl status 2>/dev/null || true
+if command -v resolvectl >/dev/null 2>&1; then
+    resolvectl status "$DEV_IF" 2>/dev/null || resolvectl status 2>/dev/null || true
+else
+    echo "/etc/resolv.conf:"
+    cat /etc/resolv.conf 2>/dev/null || echo "(no /etc/resolv.conf)"
+fi
 echo
 
 print_dns_geo


### PR DESCRIPTION
Add fallback to display /etc/resolv.conf contents when resolvectl is not available (e.g., in Alpine containers without systemd). This ensures the DNS configuration section is never empty.