### PR TITLE
Fix OpenVPN cipher deprecation warning

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -48,6 +48,12 @@ if run4 $PIN_SPEC 2>/dev/null; then
     log "$SCRIPT_NAME" "Added firewall pinhole for ${r_proto} traffic to ${r_ip}:${r_port} on interface eth0"
 fi
 
+# Add --data-ciphers if not already present in OPENVPN_OPTS
+if ! echo "$openvpn_opts" | grep -q -- "--data-ciphers"; then
+    log "$SCRIPT_NAME" "Adding default --data-ciphers to prevent cipher deprecation warning"
+    openvpn_opts="$openvpn_opts --data-ciphers AES-256-CBC:AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305"
+fi
+
 log "$SCRIPT_NAME" "Launching OpenVPN"
 openvpn --group nordvpn --config "$ovpnfile" --auth-user-pass "$authfile" --auth-nocache --management 127.0.0.1 7505 $openvpn_opts &
 


### PR DESCRIPTION
## Problem
When running the OpenVPN daemon, the following deprecation warning appears:
```
DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305). OpenVPN ignores --cipher for cipher negotiations.
```

This occurs because the `cipher` directive in the OpenVPN config file is deprecated in favor of the `--data-ciphers` command-line parameter.

## Solution
Modified `root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run` to automatically add `--data-ciphers` parameter when launching OpenVPN if it's not already present in `OPENVPN_OPTS`.

### Changes:
- Added a check before launching OpenVPN to see if `OPENVPN_OPTS` contains `--data-ciphers`
- If not present, automatically adds: `--data-ciphers AES-256-CBC:AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305`
- Logs the action for transparency

### Cipher List:
1. **AES-256-CBC** - NordVPN's default cipher (maintains compatibility)
2. **AES-256-GCM** - Modern authenticated encryption
3. **AES-128-GCM** - Faster modern cipher
4. **CHACHA20-POLY1305** - Modern cipher for non-AES hardware

### Benefits:
- ✅ Eliminates the deprecation warning by default
- ✅ Maintains backward compatibility with NordVPN's cipher configuration
- ✅ Follows OpenVPN's current best practices
- ✅ Allows users to override by setting `OPENVPN_OPTS=--data-ciphers ...`
- ✅ No breaking changes for existing users

## Testing
The fix can be tested by running the container and verifying:
1. No cipher deprecation warning appears in logs
2. VPN connection establishes successfully
3. Custom `OPENVPN_OPTS` with `--data-ciphers` still works