### PR TITLE
Add platform-specific package version support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,9 @@ ENV PATH=/command:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 
 RUN echo "**** install security fix packages ****" && \
     echo "**** install mandatory packages ****" && \
-    # PLATFORM_VERSIONS: bind-tools: default=9.20.15-r0 armv7=9.20.13-r0 riscv64=9.20.13-r0
+    # PLATFORM_VERSIONS: bind-tools: default=9.20.15-r0 armv7l=9.20.13-r0 riscv64=9.20.13-r0
     bind_tools_version=$(case $(uname -m) in \
-        armv7)          echo "9.20.13-r0"  ;; \
+        armv7l)         echo "9.20.13-r0"  ;; \
         riscv64)        echo "9.20.13-r0"  ;; \
         *)              echo "9.20.15-r0" ;; esac) && \
     apk --no-cache --no-progress add \


### PR DESCRIPTION
## Summary

This PR implements comprehensive platform-specific package version support for Alpine Linux packages in the Dockerfile, addressing cases where different architectures have different package versions available.

## Problem

Some Alpine packages are not available at the same version across all architectures. For example, `bind-tools` v9.20.15-r0 is not available for armv7 and riscv64 platforms, which only have v9.20.13-r0.

## Solution

### 1. Platform-Specific Version Infrastructure
- Added `PLATFORM_VERSIONS` comment format to specify different versions per architecture
- Implemented case statement generation for runtime architecture detection
- Format: `# PLATFORM_VERSIONS: package: default=version arch1=version arch2=version`

### 2. Automated Version Management
Enhanced `scripts/update-apk-versions.sh` to:
- Automatically check and update platform-specific versions
- Query Alpine package repositories for each architecture
- Support "default" architecture (maps to x86_64, updates wildcard pattern)
- Process entries in reverse order to prevent line number conflicts

### 3. Intelligent Optimization
- **Auto-conversion**: When all platform versions become identical, automatically convert to regular package format
- **Cleanup**: Remove platform entries that match the default version
- **Cascading**: Updates that make versions identical trigger automatic cleanup

### 4. Documentation
- Comprehensive documentation in script header
- Examples for both regular and platform-specific formats
- Usage instructions and format specifications

## Changes

### Dockerfile
- Added platform-specific version support for `bind-tools`
- Uses case statement with `uname -m` for runtime architecture detection
- Variable substitution in `apk add` command

### scripts/update-apk-versions.sh
- Added `extract_version_for_arch()` function for architecture-specific lookups
- Platform-specific version checking and updating
- Auto-conversion logic when all versions match
- Cleanup logic for redundant platform entries
- Reverse order processing for safe line deletion
- Architecture mapping (default → x86_64)

## Testing

Tested with multiple scenarios:
- ✅ 2 platforms with different versions (kept as platform-specific)
- ✅ 3 platforms where some match default (removed matching entries)
- ✅ 5 platforms updated to same version (auto-converted to regular format)
- ✅ Reverse processing prevents line number corruption

## Example

**Before:**
```dockerfile
apk add bind-tools=9.20.15-r0
```

**After:**
```dockerfile
# PLATFORM_VERSIONS: bind-tools: default=9.20.15-r0 armv7=9.20.13-r0 riscv64=9.20.13-r0
bind_tools_version=$(case $(uname -m) in \
    armv7)          echo "9.20.13-r0"  ;; \
    riscv64)        echo "9.20.13-r0"  ;; \
    *)              echo "9.20.15-r0" ;; esac) && \
apk add bind-tools=${bind_tools_version}
```

## Benefits

- 🚀 Automatic version management for all architectures
- 🔄 Self-optimizing (removes unnecessary platform logic)
- 📝 Clear documentation of platform differences
- ✅ Maintains compatibility across all supported architectures
- 🛠️ Simplifies maintenance with automated updates