### PR TITLE
Remove ppc64le and s390x from supported platforms

### DIFF
--- a/.github/workflows/ci-build-deploy.yml
+++ b/.github/workflows/ci-build-deploy.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   # Multi-platform builds for production (master/tags)
-  PLATFORMS: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x"
+  PLATFORMS: "linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64"
   # Fast builds for development branches (amd64 only)
   DEV_PLATFORMS: "linux/amd64"  # Only build for amd64 on development branches for speed
 


### PR DESCRIPTION
This pull request removes ppc64le and s390x architectures from the list of supported platforms in the CI build workflow. The PLATFORMS environment variable now only includes linux/386, linux/amd64, linux/arm/v6, linux/arm/v7, linux/arm64, and linux/riscv64.