### PR TITLE
Add jq to Dockerfile and improve update-apk-versions.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ ARG IMAGE_VERSION=N/A \
     BUILD_DATE=N/A
 
 RUN echo "**** install security fix packages ****" && \
+    echo "**** install mandatory packages ****" && \
+    apk --no-cache --no-progress add \
+        jq=1.8.0-r0 \
+        && \
     echo "**** end run statement ****"
 
 COPY root/ /rootfs/
@@ -56,6 +60,9 @@ RUN chmod +x /rootfs/usr/local/bin/* || true && \
     chmod +x /rootfs/etc/s6-overlay/s6-rc.d/*/finish || true && \
     chmod 644 /rootfs/usr/local/share/nordvpn/data/*.json && \
     chmod 644 /rootfs/usr/local/share/nordvpn/data/template.ovpn && \
+    for f in /rootfs/usr/local/share/nordvpn/data/*.json; do \
+        jq -c . "$f" > "$f.tmp" && mv "$f.tmp" "$f"; \
+    done && \
     safe_sed() { \
         local pattern="$1"; \
         local replacement="$2"; \


### PR DESCRIPTION
This PR adds the jq package to the Dockerfile for JSON processing and includes improvements to the update-apk-versions.sh script.

## Changes:
- **Dockerfile**: Added jq package to rootfs-builder stage and JSON minification loop
- **scripts/update-apk-versions.sh**: Improved output formatting, package sorting by line number, and better update reporting with line numbers

## Details:
- jq is now installed in the build stage to enable JSON processing
- Added a loop to minify JSON files using jq during the build
- Enhanced the update script with better console output and tracking