### PR TITLE
Remove serverCount from workflow MD generators

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -42,12 +42,12 @@ jobs:
         file: 
           - name: "CITIES"
             url: "https://api.nordvpn.com/v1/servers/countries"
-            jq_filter: '.[] | . as $parent | .cities[] | [$parent.name, $parent.code, $parent.id, $parent.serverCount, .name, .id, .serverCount] | "\(.[0]) | \(.[1]) | \(.[2]) | \(.[4]) | \(.[5]) | \(.[6])"'
-            header: "Country | Code | ID | City | ID | Servers"
+            jq_filter: '.[] | . as $parent | .cities[] | [$parent.name, $parent.code, $parent.id, .name, .id] | "\(.[0]) | \(.[1]) | \(.[2]) | \(.[3]) | \(.[4])"'
+            header: "Country | Code | ID | City | ID"
           - name: "COUNTRIES"
             url: "https://api.nordvpn.com/v1/servers/countries"
-            jq_filter: '.[] | [.name, .code, .id, .serverCount] | "\(.[0]) | \(.[1]) | \(.[2]) | \(.[3])"'
-            header: "Country | Code | ID | Servers"
+            jq_filter: '.[] | [.name, .code, .id] | "\(.[0]) | \(.[1]) | \(.[2])"'
+            header: "Country | Code | ID"
           - name: "TECHNOLOGIES"
             url: "https://api.nordvpn.com/v1/technologies"
             jq_filter: '.[] | [.name, .identifier, .id] | "\(.[0]) | \(.[1]) | \(.[2])"'


### PR DESCRIPTION
This PR removes the serverCount fields from the workflow's markdown generators for CITIES.md and COUNTRIES.md, aligning them with the JSON config updates that already exclude serverCount.

Changes:
- Updated jq filters to exclude serverCount data
- Modified headers to remove 'Servers' columns
- Maintains consistency between JSON and markdown outputs