### PR TITLE
fix: update jq queries to work with JSON array format

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -53,11 +53,11 @@ getcountryid()
     input=$1
 
     if is_numeric "$input"; then
-        id=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/countries.json")
+        id=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/countries.json")
     else
-        id=$(jq -r --arg NAME "$input" 'select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json")
+        id=$(jq -r --arg NAME "$input" '.[] | select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json")
         if [ -z "$id" ]; then
-            id=$(jq -r --arg CODE "$input" 'select(.code == $CODE) | .id' < "/usr/local/share/nordvpn/data/countries.json")
+            id=$(jq -r --arg CODE "$input" '.[] | select(.code == $CODE) | .id' < "/usr/local/share/nordvpn/data/countries.json")
         fi
     fi
 
@@ -75,11 +75,11 @@ getcountryname()
     input=$1
 
     if is_numeric "$input"; then
-        name=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/countries.json")
+        name=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/countries.json")
     else
-        name=$(jq -r --arg NAME "$input" 'select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json")
+        name=$(jq -r --arg NAME "$input" '.[] | select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json")
         if [ -z "$name" ]; then
-            name=$(jq -r --arg CODE "$input" 'select(.code == $CODE) | .name' < "/usr/local/share/nordvpn/data/countries.json")
+            name=$(jq -r --arg CODE "$input" '.[] | select(.code == $CODE) | .name' < "/usr/local/share/nordvpn/data/countries.json")
         fi
     fi
 
@@ -97,11 +97,11 @@ getcityid()
     input=$1
 
     if is_numeric "$input"; then
-        id=$(jq -r --argjson ID "$input" 'select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+        id=$(jq -r --argjson ID "$input" '.[] | select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
     else
-        id=$(jq -r --arg NAME "$input" 'select(.cities[]? | .name == $NAME) | .cities[] | select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+        id=$(jq -r --arg NAME "$input" '.[] | select(.cities[]? | .name == $NAME) | .cities[] | select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
         if [ -z "$id" ]; then
-            id=$(jq -r --arg DNS_NAME "$input" 'select(.cities[]? | .dns_name == $DNS_NAME) | .cities[] | select(.dns_name == $DNS_NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+            id=$(jq -r --arg DNS_NAME "$input" '.[] | select(.cities[]? | .dns_name == $DNS_NAME) | .cities[] | select(.dns_name == $DNS_NAME) | .id' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
         fi
     fi
 
@@ -119,11 +119,11 @@ getcityname()
     input=$1
 
     if is_numeric "$input"; then
-        name=$(jq -r --argjson ID "$input" 'select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+        name=$(jq -r --argjson ID "$input" '.[] | select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
     else
-        name=$(jq -r --arg NAME "$input" 'select(.cities[]? | .name == $NAME) | .cities[] | select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+        name=$(jq -r --arg NAME "$input" '.[] | select(.cities[]? | .name == $NAME) | .cities[] | select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
         if [ -z "$name" ]; then
-            name=$(jq -r --arg DNS_NAME "$input" 'select(.cities[]? | .dns_name == $DNS_NAME) | .cities[] | select(.dns_name == $DNS_NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+            name=$(jq -r --arg DNS_NAME "$input" '.[] | select(.cities[]? | .dns_name == $DNS_NAME) | .cities[] | select(.dns_name == $DNS_NAME) | .name' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
         fi
     fi
 
@@ -147,7 +147,7 @@ getcitycoordinates()
     fi
 
     # Then get coordinates using the city ID
-    coords=$(jq -r --argjson ID "$cityid" 'select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | "\(.latitude),\(.longitude)"' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
+    coords=$(jq -r --argjson ID "$cityid" '.[] | select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | "\(.latitude),\(.longitude)"' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
 
     printf '%s' "$coords"
 
@@ -168,11 +168,11 @@ getgroupid()
     fi
 
     if is_numeric "$input"; then
-        id=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/groups.json")
+        id=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/groups.json")
     else
-        id=$(jq -r --arg TITLE "$input" 'select(.title == $TITLE) | .id' < "/usr/local/share/nordvpn/data/groups.json")
+        id=$(jq -r --arg TITLE "$input" '.[] | select(.title == $TITLE) | .id' < "/usr/local/share/nordvpn/data/groups.json")
         if [ -z "$id" ]; then
-            id=$(jq -r --arg IDENTIFIER "$input" 'select(.identifier == $IDENTIFIER) | .id' < "/usr/local/share/nordvpn/data/groups.json")
+            id=$(jq -r --arg IDENTIFIER "$input" '.[] | select(.identifier == $IDENTIFIER) | .id' < "/usr/local/share/nordvpn/data/groups.json")
         fi
     fi
 
@@ -190,11 +190,11 @@ getgrouptitle()
     input=$1
 
     if is_numeric "$input"; then
-        title=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .title' < "/usr/local/share/nordvpn/data/groups.json")
+        title=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .title' < "/usr/local/share/nordvpn/data/groups.json")
     else
-        title=$(jq -r --arg TITLE "$input" 'select(.title == $TITLE) | .title' < "/usr/local/share/nordvpn/data/groups.json")
+        title=$(jq -r --arg TITLE "$input" '.[] | select(.title == $TITLE) | .title' < "/usr/local/share/nordvpn/data/groups.json")
         if [ -z "$title" ]; then
-            title=$(jq -r --arg IDENTIFIER "$input" 'select(.identifier == $IDENTIFIER) | .title' < "/usr/local/share/nordvpn/data/groups.json")
+            title=$(jq -r --arg IDENTIFIER "$input" '.[] | select(.identifier == $IDENTIFIER) | .title' < "/usr/local/share/nordvpn/data/groups.json")
         fi
     fi
 
@@ -217,11 +217,11 @@ gettechnologyid()
     fi
 
     if is_numeric "$input"; then
-        id=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
+        id=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
     else
-        id=$(jq -r --arg NAME "$input" 'select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
+        id=$(jq -r --arg NAME "$input" '.[] | select(.name == $NAME) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
         if [ -z "$id" ]; then
-            id=$(jq -r --arg IDENTIFIER "$input" 'select(.identifier == $IDENTIFIER) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
+            id=$(jq -r --arg IDENTIFIER "$input" '.[] | select(.identifier == $IDENTIFIER) | .id' < "/usr/local/share/nordvpn/data/technologies.json")
         fi
     fi
 
@@ -239,11 +239,11 @@ gettechnologyname()
     input=$1
 
     if is_numeric "$input"; then
-        name=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
+        name=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
     else
-        name=$(jq -r --arg NAME "$input" 'select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
+        name=$(jq -r --arg NAME "$input" '.[] | select(.name == $NAME) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
         if [ -z "$name" ]; then
-            name=$(jq -r --arg IDENTIFIER "$input" 'select(.identifier == $IDENTIFIER) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
+            name=$(jq -r --arg IDENTIFIER "$input" '.[] | select(.identifier == $IDENTIFIER) | .name' < "/usr/local/share/nordvpn/data/technologies.json")
         fi
     fi
 
@@ -260,10 +260,10 @@ getopenvpnprotocol()
 {
     input=$1
 
-    ident=$(jq -r --arg NAME "$input" 'select(.name == $NAME) | .identifier' < "/usr/local/share/nordvpn/data/technologies.json")
+    ident=$(jq -r --arg NAME "$input" '.[] | select(.name == $NAME) | .identifier' < "/usr/local/share/nordvpn/data/technologies.json")
     if [ -z "$ident" ]; then
         if is_numeric "$input"; then
-            ident=$(jq -r --argjson ID "$input" 'select(.id == $ID) | .identifier' < "/usr/local/share/nordvpn/data/technologies.json")
+            ident=$(jq -r --argjson ID "$input" '.[] | select(.id == $ID) | .identifier' < "/usr/local/share/nordvpn/data/technologies.json")
         fi
     fi
     if [ -z "$ident" ]; then


### PR DESCRIPTION
## Problem

Commit fb3443c converted the static data files from JSONL to JSON array format, but broke the runtime scripts that query these files.

The jq queries were using `select(.id == $ID)` which works with JSONL (one object per line) but fails with JSON arrays, producing errors like:
```
jq: error: Cannot index array with string "name"
```

## Solution

Updated all jq queries in `vpn-config` to add `.[] |` before `select()` calls to properly iterate over JSON array elements.

## Changes

- **27 jq commands updated** across all helper functions:
  - `getcountryid()` - 3 queries
  - `getcountryname()` - 3 queries
  - `getcityid()` - 3 queries
  - `getcityname()` - 3 queries
  - `getcitycoordinates()` - 1 query
  - `getgroupid()` - 3 queries
  - `getgrouptitle()` - 3 queries
  - `gettechnologyid()` - 3 queries
  - `gettechnologyname()` - 3 queries
  - `getopenvpnprotocol()` - 2 queries

## Testing

✅ Docker image built and tested successfully
✅ All lookup functions work correctly:
  - Country lookup: `Albania` → ID `2`
  - Group lookup: `Double VPN` → ID `1`
  - Technology lookup: `OpenVPN TCP` → `openvpn_tcp`
✅ VPN connection established successfully
✅ Multi-city configuration (Madrid + Barcelona) working
✅ Group filtering (P2P) working
✅ Technology filtering (OpenVPN TCP/UDP) working

## Note

The runtime `servers` variable continues to use JSONL format (built via `jq -c '.[]'`), which is optimal for incremental concatenation from multiple API calls. Only the static data files use JSON array format.