### PR TITLE
ci: add Alpine bump job and APK update hook

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -732,7 +732,7 @@ jobs:
         if: steps.update-dockerfile.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v8.0.0
         with:
-          branch: bot/update-alpine-${{ steps.get-alpine.outputs.latest }}
+          branch: bot/update-alpine
           commit-message: "deps: bump Alpine to v${{ steps.get-alpine.outputs.latest }} (${{ env.update_date }})"
           delete-branch: true
           title: "🐧 Bump Alpine to v${{ steps.get-alpine.outputs.latest }} - ${{ env.update_date }}"


### PR DESCRIPTION
## Summary

- Add 'alpine' option to maintenance workflow inputs
- Add job to detect latest Alpine and bump all FROM lines
- When bumped, also run APK version update script to keep packages aligned

## Notes

- No PR opened if Alpine version unchanged
- Uses Docker Hub tags and sort -V to pick latest stable

## Impact

- Ensures base image and packages stay in sync automatically
