### PR TITLE
ci: remove hardcoded reviewer/assignee from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,6 @@ updates:
       - "github-actions"
       - "automation"
     open-pull-requests-limit: 5
-    reviewers:
-      - "azinchen"
-    assignees:
-      - "azinchen"
 
   # Configuration for Dockerfile - Security-focused updates
   - package-ecosystem: "docker"
@@ -36,7 +32,3 @@ updates:
       - "docker"
       - "security"
     open-pull-requests-limit: 5
-    reviewers:
-      - "azinchen"
-    assignees:
-      - "azinchen"


### PR DESCRIPTION
Remove `azinchen` as `reviewers` and `assignees` from both `github-actions` and `docker` package ecosystems in `.github/dependabot.yml` to support fork development.

All remaining username references in workflows use dynamic variables (`${{ secrets.DOCKERHUB_USERNAME }}`, `${{ github.actor }}`) and require no changes.