### PR TITLE
fix: restore multi-line patch list formatting in Dockerfile and workflow

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -828,10 +828,9 @@ jobs:
             exit 0
           fi
 
-          # Build the new 'for p in ...' block (indented with 13 spaces for Dockerfile alignment)
-          PATCH_LIST=$(echo "$PATCHES" | awk 'NR==1{printf "%s", $0; next} {printf " \\\n             %s", $0}')
+          # Pass raw patch filenames (one per line) — formatting happens in the Update step
           echo "patch_list<<EOF" >> $GITHUB_OUTPUT
-          echo "$PATCH_LIST" >> $GITHUB_OUTPUT
+          echo "$PATCHES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
           echo "has_update=true" >> $GITHUB_OUTPUT
@@ -855,12 +854,21 @@ jobs:
           sed -i "s/^ARG OPENVPN_VERSION=.*/ARG OPENVPN_VERSION=${LATEST_OVPN}/" Dockerfile
           sed -i "s/^ARG OPENVPN_XOR_PATCH_VERSION=.*/ARG OPENVPN_XOR_PATCH_VERSION=${LATEST_XOR}/" Dockerfile
 
-          # Replace the 'for p in ...; do' block with the new patch list
-          # Use awk to find and replace the multi-line for block
-          awk -v patches="$PATCH_LIST" '
+          # Build the formatted for-block from raw patch filenames (one per line in PATCH_LIST)
+          FORMATTED=$(echo "$PATCH_LIST" | awk '
+            NR==1 { printf "    for p in %s", $0; next }
+            { printf " \\\n             %s", $0 }
+            END { printf "; do \\\n" }
+          ')
+
+          # Write to temp file to avoid shell escaping issues with awk -v
+          echo "$FORMATTED" > /tmp/for_block.txt
+
+          # Replace the multi-line 'for p in ...; do \' block in the Dockerfile
+          awk '
             /for p in/ {
-              printf "    for p in %s; do \\\n", patches
-              # Skip until the closing "; do"
+              while ((getline line < "/tmp/for_block.txt") > 0) print line
+              # Skip old lines until we find the "; do \" closing line
               while ($0 !~ /; do/) { getline }
               next
             }

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,11 @@ RUN echo "**** install build dependencies ****" && \
     tar xf /tmp/openvpn.tar.gz -C /tmp/openvpn --strip-components=1 && \
     echo "**** apply Tunnelblick XOR patches ****" && \
     cd /tmp/openvpn && \
-    for p in 02-tunnelblick-openvpn_xorpatch-a.diff              03-tunnelblick-openvpn_xorpatch-b.diff              04-tunnelblick-openvpn_xorpatch-c.diff              05-tunnelblick-openvpn_xorpatch-d.diff              06-tunnelblick-openvpn_xorpatch-e.diff; do \
+    for p in 02-tunnelblick-openvpn_xorpatch-a.diff \
+             03-tunnelblick-openvpn_xorpatch-b.diff \
+             04-tunnelblick-openvpn_xorpatch-c.diff \
+             05-tunnelblick-openvpn_xorpatch-d.diff \
+             06-tunnelblick-openvpn_xorpatch-e.diff; do \
         echo "Applying $p" && \
         curl -sSL "https://raw.githubusercontent.com/Tunnelblick/Tunnelblick/main/third_party/sources/openvpn/openvpn-${OPENVPN_XOR_PATCH_VERSION}/patches/$p" | \
             patch -p1 || exit 1; \


### PR DESCRIPTION
## Problem

The `update-openvpn-version` workflow collapsed the Dockerfile's multi-line `for p in ...` patch list onto a single line. This happened because `awk -v patches="$PATCH_LIST"` interprets backslash-newline sequences as line continuations, stripping the formatting.

## Fix

- **Workflow**: Pass raw patch filenames (one per line) through `GITHUB_OUTPUT` instead of pre-formatted text. The Update step now builds the formatted block locally with awk, writes it to a temp file, then uses a separate awk pass to splice it into the Dockerfile — avoiding the `-v` escaping issue.
- **Dockerfile**: Restored the multi-line `for p in` block with proper `\\` continuations.