### PR TITLE
refactor: discover XOR patch files dynamically at build time

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -828,11 +828,6 @@ jobs:
             exit 0
           fi
 
-          # Pass raw patch filenames (one per line) — formatting happens in the Update step
-          echo "patch_list<<EOF" >> $GITHUB_OUTPUT
-          echo "$PATCHES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
           echo "has_update=true" >> $GITHUB_OUTPUT
           echo "current_ovpn=${CURRENT_OVPN}" >> $GITHUB_OUTPUT
           echo "current_xor=${CURRENT_XOR}" >> $GITHUB_OUTPUT
@@ -848,32 +843,10 @@ jobs:
         env:
           LATEST_OVPN: ${{ steps.check-update.outputs.latest_ovpn }}
           LATEST_XOR: ${{ steps.check-update.outputs.latest_xor }}
-          PATCH_LIST: ${{ steps.check-update.outputs.patch_list }}
         run: |
           # Update version ARGs (OpenVPN patch may be higher than XOR patch)
           sed -i "s/^ARG OPENVPN_VERSION=.*/ARG OPENVPN_VERSION=${LATEST_OVPN}/" Dockerfile
           sed -i "s/^ARG OPENVPN_XOR_PATCH_VERSION=.*/ARG OPENVPN_XOR_PATCH_VERSION=${LATEST_XOR}/" Dockerfile
-
-          # Build the formatted for-block from raw patch filenames (one per line in PATCH_LIST)
-          FORMATTED=$(echo "$PATCH_LIST" | awk '
-            NR==1 { printf "    for p in %s", $0; next }
-            { printf " \\\n             %s", $0 }
-            END { printf "; do \\\n" }
-          ')
-
-          # Write to temp file to avoid shell escaping issues with awk -v
-          echo "$FORMATTED" > /tmp/for_block.txt
-
-          # Replace the multi-line 'for p in ...; do \' block in the Dockerfile
-          awk '
-            /for p in/ {
-              while ((getline line < "/tmp/for_block.txt") > 0) print line
-              # Skip old lines until we find the "; do \" closing line
-              while ($0 !~ /; do/) { getline }
-              next
-            }
-            { print }
-          ' Dockerfile > Dockerfile.tmp && mv Dockerfile.tmp Dockerfile
 
           echo "Updated Dockerfile to OpenVPN ${LATEST_OVPN} with XOR patches from ${LATEST_XOR}"
 
@@ -895,7 +868,7 @@ jobs:
             ### Change
             - OpenVPN: `${{ steps.check-update.outputs.current_ovpn }}` → `${{ steps.check-update.outputs.latest_ovpn }}`
             - XOR patches: `${{ steps.check-update.outputs.current_xor }}` → `${{ steps.check-update.outputs.latest_xor }}`
-            - Patch file list updated from Tunnelblick repository
+            - Patch files are discovered dynamically at build time from Tunnelblick repository
 
             ### ⚠️ Manual Steps Required
             - Verify the XOR-patched build succeeds

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN echo "**** install build dependencies ****" && \
         automake=1.18.1-r0 \
         build-base=0.5-r3 \
         curl=8.17.0-r1 \
+        jq=1.8.1-r0 \
         libcap-ng-dev=0.8.5-r0 \
         linux-headers=6.16.12-r0 \
         libnl3-dev=3.11.0-r0 \
@@ -72,16 +73,15 @@ RUN echo "**** install build dependencies ****" && \
         -o /tmp/openvpn.tar.gz && \
     mkdir -p /tmp/openvpn && \
     tar xf /tmp/openvpn.tar.gz -C /tmp/openvpn --strip-components=1 && \
-    echo "**** apply Tunnelblick XOR patches ****" && \
+    echo "**** apply Tunnelblick XOR patches ${OPENVPN_XOR_PATCH_VERSION} ****" && \
     cd /tmp/openvpn && \
-    for p in 02-tunnelblick-openvpn_xorpatch-a.diff \
-             03-tunnelblick-openvpn_xorpatch-b.diff \
-             04-tunnelblick-openvpn_xorpatch-c.diff \
-             05-tunnelblick-openvpn_xorpatch-d.diff \
-             06-tunnelblick-openvpn_xorpatch-e.diff; do \
+    PATCH_BASE="https://raw.githubusercontent.com/Tunnelblick/Tunnelblick/main/third_party/sources/openvpn/openvpn-${OPENVPN_XOR_PATCH_VERSION}/patches" && \
+    PATCH_LIST=$(curl -sf "https://api.github.com/repos/Tunnelblick/Tunnelblick/contents/third_party/sources/openvpn/openvpn-${OPENVPN_XOR_PATCH_VERSION}/patches" \
+        | jq -r '.[].name | select(contains("xorpatch"))' | sort) && \
+    [ -n "$PATCH_LIST" ] || { echo "ERROR: No XOR patches found for ${OPENVPN_XOR_PATCH_VERSION}"; exit 1; } && \
+    for p in $PATCH_LIST; do \
         echo "Applying $p" && \
-        curl -sSL "https://raw.githubusercontent.com/Tunnelblick/Tunnelblick/main/third_party/sources/openvpn/openvpn-${OPENVPN_XOR_PATCH_VERSION}/patches/$p" | \
-            patch -p1 || exit 1; \
+        curl -sSL "${PATCH_BASE}/$p" | patch -p1 || exit 1; \
     done && \
     echo "**** build OpenVPN with XOR support ****" && \
     autoreconf -ivf && \


### PR DESCRIPTION
## Summary

Instead of hardcoding the Tunnelblick XOR patch filenames in the Dockerfile (and having the workflow rewrite them on updates), query the GitHub API at build time to discover available xorpatch diffs.

## Changes

- **Dockerfile**: Add `jq` to openvpn-builder dependencies; replace static 5-file patch list with dynamic GitHub API discovery (`curl` + `jq`), with a guard that fails the build if no patches are found
- **maintenance-updates.yml**: Remove `PATCH_LIST` output, env var, and the awk-based for-block rewriting — the Update Dockerfile step now only updates the two version ARGs