### PR TITLE
ci: include XOR patches in OpenVPN update PR title

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -857,9 +857,9 @@ jobs:
           branch: bot/update-openvpn
           commit-message: "deps: bump OpenVPN to v${{ steps.check-update.outputs.latest_ovpn }}, XOR patches v${{ steps.check-update.outputs.latest_xor }} (${{ env.update_date }})"
           delete-branch: true
-          title: "🔧 Bump OpenVPN to v${{ steps.check-update.outputs.latest_ovpn }} - ${{ env.update_date }}"
+          title: "🔧 Bump OpenVPN to v${{ steps.check-update.outputs.latest_ovpn }}, XOR patches v${{ steps.check-update.outputs.latest_xor }} - ${{ env.update_date }}"
           body: |
-            ## 🔧 OpenVPN Version Update
+            ## 🔧 OpenVPN & XOR Patches Version Update
 
             **File**: `Dockerfile`
             **Date**: ${{ env.update_date }}


### PR DESCRIPTION
The auto-generated "OpenVPN Version Update" PR also bumps the Tunnelblick XOR patches version, but the PR title and body heading mentioned only OpenVPN. Update both to reflect that XOR patches are bumped as well.

### Changes
- PR title now includes the XOR patches version
- Body heading updated to "OpenVPN & XOR Patches Version Update"