### PR TITLE
ci: whitelist fields when generating countries.json

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -184,9 +184,16 @@ jobs:
           mkdir -p root/usr/local/share/nordvpn/data
           
           # Download and process countries.json with beautiful formatting
-          # Sort countries by name and cities by name within each country
+          # Whitelist only the fields we need: country id/name/code/cities,
+          # and per-city id/name/latitude/longitude/dns_name.
+          # Sort countries by name and cities by name within each country.
           curl -s "https://api.nordvpn.com/v1/servers/countries" \
-            | jq '[.[] | del(.serverCount) | .cities = ([.cities[]? | del(.serverCount, .hub_score)] | sort_by(.name))] | sort_by(.name)' \
+            | jq '[.[] | {
+                id,
+                name,
+                code,
+                cities: ([.cities[]? | {id, name, latitude, longitude, dns_name}] | sort_by(.name))
+              }] | sort_by(.name)' \
             > root/usr/local/share/nordvpn/data/countries.json
 
           UPDATE_DATE=$(date +%y%m%d)


### PR DESCRIPTION
## Summary

The NordVPN API response shape has changed. Switch the jq pipeline used to generate `countries.json` from a blacklist (`del`) approach to an explicit whitelist so only the fields we actually consume are kept.

## Fields kept

- **country:** `id`, `name`, `code`, `cities`
- **city:** `id`, `name`, `latitude`, `longitude`, `dns_name`

## Why

Using `del` only strips known extra fields, so any new fields introduced upstream silently leak into the committed JSON. Whitelisting makes the generator resilient to upstream additions/renames and keeps `countries.json` stable.

## Changes

- `.github/workflows/maintenance-updates.yml`: replace `del(.serverCount)` / `del(.serverCount, .hub_score)` with explicit object construction. Country and city sort order is preserved.