### PR TITLE
fix(ci): collapse multiple remote lines into a single __REMOTES__ placeholder

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -530,8 +530,10 @@ jobs:
           # Replace server-specific values with placeholders
           # proto → __PROTOCOL__
           sed -i '/^proto /c\proto __PROTOCOL__' "$TEMPLATE"
-          # remote line → __REMOTES__ (vpn-config generates single or multi-port remotes)
-          sed -i '/^remote /c\__REMOTES__' "$TEMPLATE"
+          # remote line(s) → single __REMOTES__ placeholder (vpn-config generates single or multi-port remotes).
+          # NordVPN configs may contain multiple `remote` entries; replace the first and delete the rest
+          # to avoid emitting one __REMOTES__ per original remote line.
+          sed -i -e '0,/^remote /s//__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
           # Add __SCRAMBLE__ placeholder after proto line (vpn-config fills or removes it)
           sed -i '/^proto __PROTOCOL__$/a __SCRAMBLE__' "$TEMPLATE"
           # verify-x509-name → __X509_NAME__


### PR DESCRIPTION
## Problem

The `Update template.ovpn` job in `.github/workflows/maintenance-updates.yml` uses:

```bash
sed -i '/^remote /c\__REMOTES__' "$TEMPLATE"
```

When the sampled NordVPN OpenVPN config contains more than one `remote` line, sed's `c\` command replaces **each** matching line individually, producing duplicate `__REMOTES__` placeholders.

This is exactly what happened in #1156, where the generated template.ovpn ended up with 4 `__REMOTES__` lines because the sampled server's TCP config advertised 4 `remote` entries.

## Fix

Replace only the first `remote` line with `__REMOTES__` and delete the remaining ones, so `vpn-config` always receives exactly one placeholder regardless of how many remotes the sample server has:

```bash
sed -i -e '0,/^remote /s//__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
```

## Notes

- Behavior is unchanged for sampled configs with a single `remote` line (the common case).
- Closes the root cause behind the duplicate-placeholders seen in #1156; that PR can be closed once the next scheduled run regenerates the template correctly.