### PR TITLE
fix(ci): match entire remote line when collapsing to __REMOTES__

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -531,9 +531,10 @@ jobs:
           # proto → __PROTOCOL__
           sed -i '/^proto /c\proto __PROTOCOL__' "$TEMPLATE"
           # remote line(s) → single __REMOTES__ placeholder (vpn-config generates single or multi-port remotes).
-          # NordVPN configs may contain multiple `remote` entries; replace the first and delete the rest
-          # to avoid emitting one __REMOTES__ per original remote line.
-          sed -i -e '0,/^remote /s//__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
+          # NordVPN configs may contain multiple `remote` entries; replace the first whole line and
+          # delete the rest to avoid emitting one __REMOTES__ per original remote line or leaving the
+          # original IP/port text appended to the placeholder.
+          sed -i -e '0,/^remote /s/^remote .*/__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
           # Add __SCRAMBLE__ placeholder after proto line (vpn-config fills or removes it)
           sed -i '/^proto __PROTOCOL__$/a __SCRAMBLE__' "$TEMPLATE"
           # verify-x509-name → __X509_NAME__


### PR DESCRIPTION
## Problem

Follow-up to #1159. The previous fix used:

```bash
sed -i -e '0,/^remote /s//__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
```

In sed, `s//replacement/` reuses the **last regex** (here `^remote `), so the substitution only replaces the *matched prefix*, not the whole line. As a result the IP and port from the sampled config remained appended to the placeholder, producing lines like:

```
__REMOTES__45.12.220.227 1231
```

See #1161 for the regenerated template showing this.

## Fix

Match the entire `remote` line explicitly so the full line (prefix + IP + port) is replaced:

```bash
sed -i -e '0,/^remote /s/^remote .*/__REMOTES__/' -e '/^remote /d' "$TEMPLATE"
```

## Verification

```console
$ printf 'client\nproto tcp\nremote 45.12.220.227 1231\nremote 1.2.3.4 443\nresolv-retry infinite\n' \
    | sed -e '0,/^remote /s/^remote .*/__REMOTES__/' -e '/^remote /d'
client
proto tcp
__REMOTES__
resolv-retry infinite
```

Once merged, #1161 can be closed and the next scheduled run will regenerate `template.ovpn` correctly.