### PR TITLE
fix(vpn-config): prevent silent exit on unknown country/city/group/tech

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -160,7 +160,9 @@ getcitycoordinates()
     input=$1
 
     # First get the city ID using existing function
-    cityid=$(getcityid "$input")
+    # `|| true` prevents `set -e` from killing the caller via command substitution
+    # when getcityid returns 1; the -z guard below handles the empty result.
+    cityid=$(getcityid "$input" || true)
     if [ -z "$cityid" ]; then
         return 1
     fi
@@ -388,7 +390,10 @@ locations_count=0
 # Validate technology and group IDs and build filter strings
 tech_filter=""
 if [ -n "$technology" ]; then
-    tech_id=$(gettechnologyid "$technology")
+    # `|| true` prevents `set -e` from terminating the script via the
+    # command substitution when gettechnologyid returns 1 (unknown value);
+    # the -z guard below logs the proper warning instead.
+    tech_id=$(gettechnologyid "$technology" || true)
     if [ -z "$tech_id" ]; then
         log_warning "$SCRIPT_NAME" "Warning: Could not find technology \"$technology\""
     else
@@ -400,7 +405,8 @@ fi
 
 group_filter=""
 if [ -n "$group" ]; then
-    group_id=$(getgroupid "$group")
+    # See gettechnologyid above for the rationale behind `|| true`.
+    group_id=$(getgroupid "$group" || true)
     if [ -z "$group_id" ]; then
         log_warning "$SCRIPT_NAME" "Warning: Could not find group \"$group\""
     else
@@ -426,7 +432,10 @@ if [ -n "$country" ]; then
             log_warning "$SCRIPT_NAME" "Warning: Ensure server $value supports TECHNOLOGY=$technology and GROUP=$group, otherwise connection will fail"
             servers="$servers$(handle_specific_server "$value")"
         elif [ -n "$value" ]; then
-            countryid=$(getcountryid "$value")
+            # `|| true` so an unknown country (e.g. user passing a US state code)
+            # doesn't silently kill the script under `set -e`; the -z branch
+            # below logs a warning and the loop continues with remaining values.
+            countryid=$(getcountryid "$value" || true)
             if [ -n "$countryid" ]; then
                 # Build curl parameters
                 curl_params="--data-urlencode filters[country_id]=$countryid"
@@ -467,7 +476,8 @@ if [ -n "$city" ]; then
             log_warning "$SCRIPT_NAME" "Warning: Ensure server $value supports TECHNOLOGY=$technology and GROUP=$group, otherwise connection will fail"
             servers="$servers$(handle_specific_server "$value")"
         elif [ -n "$value" ]; then
-            coords=$(getcitycoordinates "$value")
+            # See COUNTRY loop above for the rationale behind `|| true`.
+            coords=$(getcitycoordinates "$value" || true)
             if [ -n "$coords" ]; then
                 latitude=$(echo "$coords" | cut -d',' -f1)
                 longitude=$(echo "$coords" | cut -d',' -f2)


### PR DESCRIPTION
## Summary

Fixes #1148.

`vpn-config` silently exits under `set -eu` when a helper lookup function returns 1 inside a `var=$(helper …)` command substitution. The intended `[ -z "$var" ]` warning branches are never reached, so an unknown value (e.g. `COUNTRY="United States;TX"` where `TX` is a US state, not a NordVPN country code) kills the script right after the server list is printed. s6 then restarts the service in a loop and the tunnel never comes up — exactly what the user in #1148 observed.

## Root cause

Under POSIX `set -e`, a failing command substitution in an assignment terminates the shell:

```sh
set -e
x=$(false)   # script exits here, silently
echo "never reached"
```

The following captures in `root/usr/local/bin/vpn-config` all hit this:

- `cityid=$(getcityid "$input")` (via `getcitycoordinates`)
- `tech_id=$(gettechnologyid "$technology")`
- `group_id=$(getgroupid "$group")`
- `countryid=$(getcountryid "$value")` ← triggered by #1148
- `coords=$(getcitycoordinates "$value")`

(`country_id=$(getcountryid "$cc" 2>/dev/null || echo "")` in `handle_specific_server` was already protected.)

## Fix

Append `|| true` to each affected capture so the helper's exit code can no longer terminate the script. The existing `-z` guards then run and log the proper warning, and the loop continues with the remaining values.

## Reproduction

`docker-compose.yml`:
```yaml
environment:
  - COUNTRY=United States;TX
  - RANDOM_TOP=10
  - USER=...
  - PASS=...
```

### Before (current `master`)

```
[VPN-CONFIG] Fetched 20 servers for United States
us12582.nordvpn.com: 16% load - United States, Detroit ...
...
[SERVICE-NORDVPN] Stopping NordVPN service        ← silent death, no warning
[SERVICE-NORDVPN] Cleaning up VPN firewall rules
...                                                ← restart loop, never connects
```

### After (this PR)

```
[VPN-CONFIG] Fetched 20 servers for United States
[VPN-CONFIG] [WARNING] Warning: Could not find country "TX"
[VPN-CONFIG] Server pool contains 20 servers
[VPN-CONFIG] Selected server: United States #12613 (us12613.nordvpn.com, United States, Columbus)
[VPN-CONFIG] Configuring VPN settings (IP: 216.183.115.72, Protocol: udp)
[VPN-CONFIG] VPN configuration completed
... VPN connects, public IP confirmed via network-diagnostic ...
```

## Notes

- Behavior for valid inputs is unchanged.
- The user's `COUNTRY=United States;TX` config is still semantically wrong (the second token must be another country code/name, not a US state); the right way to filter to Texas is `CITY=Dallas`/`CITY=Houston`. But the script should warn and continue instead of dying silently — which is what this PR restores.
