### PR TITLE
ci: mark virtual locations in COUNTRIES.md with legend

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -50,7 +50,7 @@ jobs:
             header: "Country | Code | ID | City | ID | Map"
           - name: "COUNTRIES"
             url: "https://api.nordvpn.com/v1/servers/countries"
-            jq_filter: 'sort_by(.name) | .[] | [.name, .code, .id] | "\(.[0]) | \(.[1]) | \(.[2])"'
+            jq_filter: 'sort_by(.name) | .[] | . as $c | "\($c.name)\(if ($virtual | index($c.id)) then " **" elif ($partial | index($c.id)) then " *" else "" end) | \($c.code) | \($c.id)"'
             header: "Country | Code | ID"
           - name: "TECHNOLOGIES"
             url: "https://api.nordvpn.com/v1/technologies"
@@ -69,18 +69,27 @@ jobs:
         id: update-file
         shell: bash
         run: |
-          # Build the table body. CITIES additionally marks virtual locations
-          # (cities NordVPN advertises but whose servers are physically hosted
-          # elsewhere) with a "*" and gets an explanatory legend at the top.
-          # The virtual flag lives on the /v1/servers endpoint
-          # (specifications -> virtual_location), not on /v1/servers/countries.
+          # Build the table body. CITIES and COUNTRIES additionally mark virtual
+          # locations (servers NordVPN advertises but whose physical hardware is
+          # hosted elsewhere) and get an explanatory legend at the top. The virtual
+          # flag lives on the /v1/servers endpoint (specifications ->
+          # virtual_location), not on /v1/servers/countries.
           LEGEND=$'\n'
           if [ "${{ matrix.file.name }}" == "CITIES" ]; then
-            LEGEND=$'\n> Cities marked with `*` are virtual locations: NordVPN advertises a server in that city but the physical hardware is hosted in a nearby country.\n\n'
+            LEGEND=$'\n> Cities marked with `*` are virtual locations: NordVPN advertises a server at this location but its physical hardware is hosted elsewhere.\n\n'
             # limit=0 returns the full server list (no cap); omitting limit defaults to only 100.
             VIRTUAL_IDS=$(curl -s "https://api.nordvpn.com/v1/servers?limit=0" \
               | jq -c '[.[] | select(any(.specifications[]?; .identifier=="virtual_location" and .values[0].value=="true")) | .locations[0].country.city.id] | unique')
             BODY=$(curl -s "${{ matrix.file.url }}" | jq -r --argjson virtual "${VIRTUAL_IDS:-[]}" '${{ matrix.file.jq_filter }}')
+          elif [ "${{ matrix.file.name }}" == "COUNTRIES" ]; then
+            LEGEND=$'\n> Countries marked with `**` host only virtual servers (advertised by NordVPN at this location but whose physical hardware is hosted elsewhere); countries marked with `*` host a mix of virtual and physical servers. Unmarked countries host only physical servers.\n\n'
+            # limit=0 returns the full server list (no cap); omitting limit defaults to only 100.
+            # Classify each country by whether all, some, or none of its servers are virtual.
+            CLASSIFY=$(curl -s "https://api.nordvpn.com/v1/servers?limit=0" \
+              | jq -c '[.[] | {cid: .locations[0].country.id, v: (any(.specifications[]?; .identifier=="virtual_location" and .values[0].value=="true"))}] | group_by(.cid) | map({cid: .[0].cid, total: length, virt: (map(select(.v)) | length)}) | {virtual_only: ([.[] | select(.virt==.total) | .cid] | unique), partial: ([.[] | select(.virt>0 and .virt<.total) | .cid] | unique)}')
+            VIRTUAL_IDS=$(echo "${CLASSIFY:-{\}}" | jq -c '.virtual_only // []')
+            PARTIAL_IDS=$(echo "${CLASSIFY:-{\}}" | jq -c '.partial // []')
+            BODY=$(curl -s "${{ matrix.file.url }}" | jq -r --argjson virtual "${VIRTUAL_IDS:-[]}" --argjson partial "${PARTIAL_IDS:-[]}" '${{ matrix.file.jq_filter }}')
           else
             BODY=$(curl -s "${{ matrix.file.url }}" | jq -r '${{ matrix.file.jq_filter }}')
           fi


### PR DESCRIPTION
## Summary

Marks virtual NordVPN locations in `COUNTRIES.md` and adds an explanatory legend at the top of the file, following the same approach as #1175 (which did this for `CITIES.md`).

### Background

NordVPN advertises some locations as "virtual" — the server is presented as being in that location, but the physical hardware is hosted elsewhere. This flag is not available on the `/v1/servers/countries` endpoint (which only has geo + counts); it lives on `/v1/servers` inside each server's `specifications` array (`identifier: "virtual_location"`).

Unlike cities, a country can host a mix of virtual and physical servers, so countries are classified into three states.

### Changes (`update-readme-files` job)

- The COUNTRIES `jq_filter` now takes `$virtual` and `$partial` args and appends a marker to each country based on its classification.
- The generation step special-cases COUNTRIES: it fetches `/v1/servers?limit=0`, groups servers by country id, and classifies each country as virtual-only, partial, or physical. A legend blockquote is prepended explaining the markers.
- The existing CITIES legend wording was aligned ("its physical hardware is hosted elsewhere").
- Non-COUNTRIES/CITIES files (TECHNOLOGIES, GROUPS) are unchanged.

### Marking convention

- `**` — country hosts **only** virtual servers
- `*` — country hosts a **mix** of virtual and physical servers
- *(unmarked)* — country hosts only physical servers

### Notes

- `COUNTRIES.md` itself is intentionally not regenerated here; it will be updated by the scheduled `Maintenance - Automated Updates` workflow.
- First workflow run will produce a large one-time diff since most countries gain a marker.

---
🤖 Generated with assistance from GitHub Copilot