### PR TITLE
docs: deep-link README and wiki references to exact sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Check the **[Troubleshooting][wiki-troubleshoot]** and **[FAQ][wiki-faq]** wiki 
 [wiki-home]: https://github.com/azinchen/nordvpn/wiki
 [wiki-server]: https://github.com/azinchen/nordvpn/wiki/Server-Selection
 [wiki-reconnect]: https://github.com/azinchen/nordvpn/wiki/Automatic-Reconnection
-[wiki-security]: https://github.com/azinchen/nordvpn/wiki/Security-Model
+[wiki-security]: https://github.com/azinchen/nordvpn/wiki/Security-Model#traffic-control--kill-switch
 [wiki-network]: https://github.com/azinchen/nordvpn/wiki/Local-Network-Access
 [wiki-ipv6]: https://github.com/azinchen/nordvpn/wiki/IPv6-Configuration
 [wiki-firewall]: https://github.com/azinchen/nordvpn/wiki/Firewall-Backends
-[wiki-tech]: https://github.com/azinchen/nordvpn/wiki/Technologies
+[wiki-tech]: https://github.com/azinchen/nordvpn/wiki/Technologies#xor-obfuscated-openvpn-openvpn_xor_udp--openvpn_xor_tcp
 [wiki-compose]: https://github.com/azinchen/nordvpn/wiki/Docker-Compose-Examples
 [wiki-run]: https://github.com/azinchen/nordvpn/wiki/Docker-Run-Examples
 [wiki-troubleshoot]: https://github.com/azinchen/nordvpn/wiki/Troubleshooting


### PR DESCRIPTION
## Summary

Updates cross-references in the README and wiki so that links pointing to a specific sub-topic resolve to the exact section anchor instead of the top of the target page.

For example, the **XOR Obfuscation** feature link in the README now points to the `## XOR Obfuscated OpenVPN (openvpn_xor_udp / openvpn_xor_tcp)` section of the Technologies page.

Links whose target page is entirely about the linked concept (e.g. Server Selection, Local Network Access, IPv6 Configuration, Firewall Backends) and page-level navigation lists (`Home.md`, `_Sidebar.md`) were intentionally left at page level.

## Changes

**README.md**
- XOR Obfuscation → `Technologies#xor-obfuscated-openvpn-openvpn_xor_udp--openvpn_xor_tcp`
- Kill Switch → `Security-Model#traffic-control--kill-switch`

**Wiki** (committed separately to the wiki repo; this PR bumps the submodule pointer)
- `Architecture-and-Internals.md` → `Technologies#multi-port-behavior`
- `Docker-Run-Examples.md` → XOR section
- `Server-Groups.md` → XOR section
- `Troubleshooting.md` → `Automatic-Reconnection#connection-health-monitoring`, `Technologies#multi-port-behavior`
- `Docker-Compose-Examples.md` → `Updating-and-Maintenance#why-dependent-containers-must-restart`, XOR section
- `FAQ.md` → `Technologies#supported-technologies`, `Updating-and-Maintenance#why-dependent-containers-must-restart`, `Security-Model#traffic-control--kill-switch`

Anchors follow GitHub's slug rules (lowercase, punctuation stripped, spaces → hyphens).