### PR TITLE
fix: avoid 'File exists' error when restoring resolv.conf in down.sh

### DIFF
--- a/root/etc/openvpn/down.sh
+++ b/root/etc/openvpn/down.sh
@@ -6,7 +6,10 @@
 
 _backup="/etc/resolv.conf.ovpn-${dev}"
 if [ -f "$_backup" ]; then
-    cp "$_backup" /etc/resolv.conf
+    # Write into the existing inode instead of replacing the file:
+    # /etc/resolv.conf is usually a Docker-managed (or user) bind mount and
+    # cannot be recreated ("cp: can't create '/etc/resolv.conf': File exists").
+    cat "$_backup" > /etc/resolv.conf
     rm -f "$_backup"
 fi
 


### PR DESCRIPTION
## Problem

The OpenVPN down script logs the following error on disconnect/shutdown:

```
cp: can't create '/etc/resolv.conf': File exists
```

`/etc/resolv.conf` is a Docker-managed bind mount (the same applies when a user bind-mounts their own `resolv.conf`). A bind-mounted file is a mount point and cannot be replaced/recreated, so BusyBox `cp` fails with `File exists`.

Notably, `up.sh` does **not** hit this because it writes into the existing inode via shell redirection (`> /etc/resolv.conf`). Only `down.sh` used `cp`.

## Fix

Replace `cp "$_backup" /etc/resolv.conf` with `cat "$_backup" > /etc/resolv.conf`, which writes into the existing inode instead of attempting to recreate the mount point. This mirrors the approach already used in `up.sh`.

## Impact

- Eliminates the misleading error in the logs.
- DNS restore behavior is unchanged (the backup contents are still written to `/etc/resolv.conf`).