### PR TITLE
Remove obsolete top-level 'version' field from Compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Also available from GitHub Container Registry: `ghcr.io/azinchen/nordvpn`
 ## Docker Compose Example
 
 ```yaml
-version: "3.8"
 services:
   vpn:
     image: azinchen/nordvpn:latest


### PR DESCRIPTION
## Summary

The top-level `version` field (e.g. `version: "3.8"`) is obsolete in the current Compose Specification. Docker Compose V2 ignores it and emits a warning:

> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

This PR removes it from all documented Compose examples.

## Changes

- **README.md** — removed `version: "3.8"` from the Docker Compose example.
- **wiki** (submodule) — removed `version: "3.8"` from all 4 Compose examples in `Docker-Compose-Examples.md`; submodule pointer bumped accordingly.

> Note: the wiki changes live in the `nordvpn.wiki` repo (GitHub wikis don't support PRs), pushed to branch `remove-obsolete-compose-version`. This PR's submodule pointer references that commit.