### PR TITLE
ci: disable docker dependabot in favor of maintenance workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,18 +17,6 @@ updates:
       - "automation"
     open-pull-requests-limit: 5
 
-  # Configuration for Dockerfile - Security-focused updates
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"  # More frequent for security
-      time: "04:00"
-      timezone: "UTC"
-    commit-message:
-      prefix: "docker"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "docker"
-      - "security"
-    open-pull-requests-limit: 5
+  # Docker base image (Alpine) updates are handled by the
+  # "Update Alpine Version" job in .github/workflows/maintenance-updates.yml,
+  # so Dockerfile updates are intentionally not managed by Dependabot.


### PR DESCRIPTION
## Summary

Disables the `docker` package-ecosystem in `.github/dependabot.yml`.

Alpine base image bumps are already handled by the **Update Alpine Version** job in `.github/workflows/maintenance-updates.yml`, so Dependabot's docker updates produced duplicate PRs (e.g. #1186).

## Changes
- Remove the `docker` ecosystem block from `dependabot.yml`
- Add a comment documenting that Dockerfile/Alpine updates are managed by the maintenance workflow
