### PR TITLE
fix: stop injecting --data-ciphers into OPENVPN_OPTS

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -49,12 +49,6 @@ awk '/^[[:space:]]*remote[ \t]+/ {print $2, $3}' "$ovpnfile" | while read -r r_i
     fi
 done
 
-# Add --data-ciphers if not already present in OPENVPN_OPTS
-if ! echo "$openvpn_opts" | grep -q -- "--data-ciphers"; then
-    log "$SCRIPT_NAME" "Adding default --data-ciphers to prevent cipher deprecation warning"
-    openvpn_opts="$openvpn_opts --data-ciphers AES-256-CBC:AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305"
-fi
-
 # Write extra options to a config fragment so OpenVPN parses them
 # directly (avoids eval and preserves quoted multi-word arguments)
 openvpn_extra="/run/xt/openvpn-extra.conf"


### PR DESCRIPTION
## Summary

Removes the code in `svc-nordvpn/run` that automatically appended a default `--data-ciphers` list to `OPENVPN_OPTS`. The data cipher is negotiated with the NordVPN server, so injecting a default list was unnecessary.

The remaining OpenVPN notice — `DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (DEFAULT)` — is harmless (the server still negotiates `AES-256-GCM`) and is now documented in the wiki FAQ, along with how to suppress it via `OPENVPN_OPTS`.

## Changes

- **`root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run`**: remove the `--data-ciphers` injection block.
- **wiki** (submodule bump `5928e49` → `ecec2e3`):
  - FAQ: explain the `--cipher missing in --data-ciphers` notice and how to silence it with `OPENVPN_OPTS=--data-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC`.
  - Architecture & Internals: document that `data/` files are auto-generated from NordVPN's API/CDN by the `maintenance-updates` workflow and shouldn't be hand-edited.

## Verification

Built and ran the image via `docker compose`; confirmed the connection succeeds and negotiates `Data Channel: cipher 'AES-256-GCM'` while the deprecation notice is purely cosmetic.

> **Note:** the wiki submodule branch `docs/data-ciphers-warning` must be merged into the wiki's `master` separately (GitHub wikis don't support PRs).