### PR TITLE
Scope VPN server firewall dispatch rules to eth0

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -35,8 +35,8 @@ if [ -n "$docker_network" ]; then
     # Do not restrict by port here — svc-nordvpn adds per-IP:port rules
     # into VPN-SERVER at runtime (XOR uses non-standard ports)
     run4 -N VPN-SERVER
-    run4 -A OUTPUT -p udp -j VPN-SERVER
-    run4 -A OUTPUT -p tcp -j VPN-SERVER
+    run4 -A OUTPUT -o eth0 -p udp -j VPN-SERVER
+    run4 -A OUTPUT -o eth0 -p tcp -j VPN-SERVER
 
     # NordVPN API bootstrap (TCP/443) by resolved IPs
     if [ -n "$nordvpnapi_ip" ]; then


### PR DESCRIPTION
## Summary

Scope the `VPN-SERVER` dispatch rules to `eth0`.

Previously, all outbound TCP/UDP traffic entered the `VPN-SERVER` chain:

```iptables
-A OUTPUT -p udp -j VPN-SERVER
-A OUTPUT -p tcp -j VPN-SERVER
```

Now only TCP/UDP traffic leaving through `eth0` is dispatched there:

```iptables
-A OUTPUT -o eth0 -p udp -j VPN-SERVER
-A OUTPUT -o eth0 -p tcp -j VPN-SERVER
```

## Why

`VPN-SERVER` is only used for dynamic pinholes to the active VPN peer outside the tunnel. That traffic is expected to leave through `eth0`.

This avoids sending unrelated TCP/UDP traffic from other interfaces, such as `tun0` or `lo`, through the VPN server chain.

## Scope

No behavior changes to VPN peer detection, OpenVPN startup, NAT, DNS, LAN rules, or forwarding.

Only the static `OUTPUT` jump rules were narrowed.
