### PR TITLE
feat: add FORWARD_FROM for VPN gateway mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ services:
 | **CHECK<wbr>_CONNECTION<wbr>_ATTEMPTS** | Connection test retry count. Default: `5` |
 | **CHECK<wbr>_CONNECTION<wbr>_ATTEMPT<wbr>_INTERVAL** | Seconds between retries. Default: `10` |
 | **NETWORK** | LAN/inter‑container CIDRs to allow; semicolon‑separated. Default: none |
+| **FORWARD<wbr>_FROM** | Downstream CIDRs allowed to route OUT through the tunnel (gateway mode). Traffic must arrive already SNATed into these nets. Semicolon‑ or comma‑separated. Default: none |
 | **NORDVPNAPI<wbr>_IP** | API bootstrap IPs (semicolon‑separated). Default: `104.16.208.203;104.19.159.190` |
 | **XOR<wbr>_KEY** | XOR scramble obfuscation key for `openvpn_xor_*` technologies. Default: NordVPN's built-in key |
 | **OPENVPN<wbr>_OPTS** | Additional OpenVPN parameters. |

--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -66,6 +66,23 @@ if [ -n "$docker_network" ]; then
         done
         IFS="$oldIFS"
     fi
+
+    # FORWARD_FROM rules (CIDRs). Downstream subnets allowed to route OUT through
+    # the tunnel (e.g. a VPN server living behind us). Traffic must arrive already
+    # SNATed into one of these nets so no return route is required. Semicolon- or
+    # comma-separated; only FORWARD is opened — INPUT/OUTPUT stay locked, so if the
+    # tunnel is down these rules cannot match and nothing leaks.
+    if [ -n "${forward_from:-}" ]; then
+        log "$SCRIPT_NAME" "Allowing tunnel forwarding from: ${forward_from}"
+        oldIFS="$IFS"; IFS=',;'
+        for net in $forward_from; do
+            [ -z "$net" ] && continue
+            run4_critical -A FORWARD -s "$net" -o tun0 -j ACCEPT
+            run4_critical -A FORWARD -d "$net" -i tun0 \
+                -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+        done
+        IFS="$oldIFS"
+    fi
 else
     log "$SCRIPT_NAME" "No IPv4 address on eth0, skipping IPv4 rules"
 fi

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -24,6 +24,7 @@ recreate_vpn_cron="${RECREATE_VPN_CRON:-}"
 check_connection_cron="${CHECK_CONNECTION_CRON:-}"
 nordvpnapi_ip="${NORDVPNAPI_IP:-104.16.208.203;104.19.159.190}"
 network="${NETWORK:-}"
+forward_from="${FORWARD_FROM:-}"
 puid=${PUID:-912}
 pgid=${PGID:-912}
 


### PR DESCRIPTION
## Summary

Adds a `FORWARD_FROM` variable that turns the container into a VPN **gateway** for downstream containers that keep their own network namespace (e.g. an ocserv/WireGuard server whose clients should exit through NordVPN).

This is the inverse of `NETWORK`: `NETWORK` lets traffic *bypass* the tunnel to reach the LAN, while `FORWARD_FROM` lets a downstream subnet *route out through* the tunnel.

## Changes

- `backend-functions`: map `FORWARD_FROM` → `$forward_from`.
- `init-firewall/run`: for each CIDR, open `FORWARD -s <cidr> -o tun0` plus the `ESTABLISHED,RELATED` return path. Semicolon/comma-separated, matching `NETWORK`.
- `README.md`: document the variable in the env table.
- Wiki: new **VPN Gateway Mode** page + sidebar link (submodule pointer bumped).

## Behaviour & safety

- Reuses the existing `POSTROUTING -o tun0 -j MASQUERADE` rule — no extra NAT.
- Only `FORWARD` is opened; `INPUT`/`OUTPUT` stay locked. Rules reference `tun0`, so if the tunnel drops they can't match — forwarding stops with the kill switch, no leak.
- Requires `net.ipv4.ip_forward=1` and that downstream traffic arrives already SNATed into one of the `FORWARD_FROM` nets (so no return route is needed).

## Notes

- The wiki branch `feat/forward-from-gateway-mode` (in the wiki repo) must be merged into the wiki `master` for the page to render and for the submodule pointer to remain valid after merge.