### PR TITLE
fix: filter CITY by country_city_id instead of coordinates

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -155,30 +155,6 @@ getcityname()
     return 0
 }
 
-getcitycoordinates()
-{
-    input=$1
-
-    # First get the city ID using existing function
-    # `|| true` prevents `set -e` from killing the caller via command substitution
-    # when getcityid returns 1; the -z guard below handles the empty result.
-    cityid=$(getcityid "$input" || true)
-    if [ -z "$cityid" ]; then
-        return 1
-    fi
-
-    # Then get coordinates using the city ID
-    coords=$(jq -r --argjson ID "$cityid" '.[] | select(.cities[]? | .id == $ID) | .cities[] | select(.id == $ID) | "\(.latitude),\(.longitude)"' < "/usr/local/share/nordvpn/data/countries.json" | head -n 1)
-
-    printf '%s' "$coords"
-
-    if [ -z "$coords" ] || [ "$coords" = "null,null" ]; then
-        return 1
-    fi
-
-    return 0
-}
-
 getgroupid()
 {
     input=$1
@@ -477,20 +453,17 @@ if [ -n "$city" ]; then
             servers="$servers$(handle_specific_server "$value")"
         elif [ -n "$value" ]; then
             # See COUNTRY loop above for the rationale behind `|| true`.
-            coords=$(getcitycoordinates "$value" || true)
-            if [ -n "$coords" ]; then
-                latitude=$(echo "$coords" | cut -d',' -f1)
-                longitude=$(echo "$coords" | cut -d',' -f2)
-                
+            cityid=$(getcityid "$value" || true)
+            if [ -n "$cityid" ]; then
                 # Build curl parameters
-                curl_params="--data-urlencode coordinates[latitude]=$latitude --data-urlencode coordinates[longitude]=$longitude"
+                curl_params="--data-urlencode filters[country_city_id]=$cityid"
                 if [ -n "$tech_filter" ]; then
                     curl_params="$curl_params $tech_filter"
                 fi
                 if [ -n "$group_filter" ]; then
                     curl_params="$curl_params $group_filter"
                 fi
-                
+
                 # Execute curl with built parameters
                 serversincity=$(eval "nord_api_curl \"v1/servers/recommendations\" $curl_params 2>/dev/null | jq -c '.[]' 2>/dev/null || echo \"\"")
                 if [ -n "$serversincity" ]; then
@@ -501,7 +474,7 @@ if [ -n "$city" ]; then
                     log_warning "$SCRIPT_NAME" "Warning: No servers returned for city \"$value\""
                 fi
             else
-                log_warning "$SCRIPT_NAME" "Warning: Could not find coordinates for city \"$value\""
+                log_warning "$SCRIPT_NAME" "Warning: Could not find city \"$value\""
             fi
         fi
     done


### PR DESCRIPTION
## Problem

The `CITY` selector resolved a city to its latitude/longitude and queried `v1/servers/recommendations` with `coordinates[latitude]/[longitude]`. That endpoint returns the geographically **nearest** recommended servers — not servers in the requested city.

Observed: `CITY=Detroit` returned **only Pittsburgh** servers (`us123xx`, ~450 km away), and never any Detroit servers.

Verified against the live API (same token/endpoint):

| Query | Result |
|---|---|
| `coordinates[...]` (old) | `us123xx` → **Pittsburgh** |
| `filters[country_city_id]=8903312` (new) | `us125xx` → **Detroit** ✅ |

The bundled `countries.json` was already correct (Detroit `id=8903312`, correct coordinates) — only the query *method* was wrong.

## Fix

- Switch the `CITY` branch to `filters[country_city_id]=<cityid>` via the existing `getcityid`, mirroring the `COUNTRY` branch and the `nordvpn-helper` tool.
- Remove the now-unused `getcitycoordinates()` helper.

## Notes on result size

No `limit` is set, matching the `COUNTRY` branch — the API returns its default load-sorted pool, which feeds `RANDOM_TOP`:

| City | Total servers | Returned |
|---|---|---|
| Detroit | 10 | 10 |
| London | 882 | 20 (default cap) |
| New York | 631 | 20 |

i.e. `min(available, 20)` — the best load-sorted recommendations, which is the desired behavior.

## Testing

Built and ran via `docker-compose.yml` with `CITY=Detroit`:

```
[VPN-CONFIG] Fetched 10 servers for Detroit
us12580.nordvpn.com: 26% load - United States, Detroit (United States #12580)
...
[VPN-CONFIG] Selected server: United States #12587 (us12587.nordvpn.com, United States, Detroit)
Initialization Sequence Completed
VPN Status : Connected
```