### PR TITLE
reconnect: poll for OpenVPN exit instead of fixed sleep on stop

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
@@ -23,7 +23,21 @@ if is_mgmt_available; then
 else
     log "$SCRIPT_NAME" "Management interface not available, skipping graceful shutdown"
 fi
-sleep 5
+
+# Wait for OpenVPN to actually exit so the next service start can rebind the
+# management port (7505) and recreate tun0. OpenVPN is orphaned when run's shell
+# is signalled, so we poll its resources instead of waiting on the PID. Polling
+# (vs a fixed sleep) returns the moment it's gone, cutting reconnect downtime;
+# the loop still caps the wait so a stuck shutdown can't hang finish.
+wait_counter=0
+while is_mgmt_available || is_vpn_connected; do
+    wait_counter=$((wait_counter + 1))
+    if [ "$wait_counter" -ge 50 ]; then
+        log "$SCRIPT_NAME" "OpenVPN still shutting down after timeout, continuing"
+        break
+    fi
+    sleep 0.1
+done
 
 log "$SCRIPT_NAME" "Cleaning up VPN configuration files"
 rm -f "$ovpnfile"


### PR DESCRIPTION
## Summary

The `svc-nordvpn` `finish` script sent `SIGTERM` to the (orphaned) OpenVPN process via the management interface and then slept a **fixed 5 s** before cleanup, to let it release the management port (7505) and `tun0` so the next service start could rebind them. OpenVPN almost always exits well under a second, so that fixed sleep added needless downtime to every reconnect.

This replaces the blind `sleep 5` with a poll on those resources (`is_mgmt_available` / `is_vpn_connected`) that returns the moment OpenVPN is gone, capped at 5 s so a stuck shutdown can't hang `finish`. It complements dd1bc99, which moved server selection out of the downtime window — that removed the slow API/selection work; this removes the remaining fixed-time padding from teardown.

## Why the wait is still needed (not eliminated)

`run` launches OpenVPN with `&` + `wait` (no `exec`), so the supervised process is the shell; on stop, OpenVPN is orphaned and must be killed from `finish`. The next start immediately launches a new OpenVPN with `--management 127.0.0.1 7505`, which fails to bind if the old process is still alive. So a wait is required — just not a fixed-length one.

## Testing

Built the image and ran a live container (NordVPN/Detroit), then triggered repeated reconnects:

- Stop→start teardown wait dropped from a fixed 5 s to **sub-second** (`Sent SIGTERM` and `service stopped` share the same log second across both runs).
- New OpenVPN bound port 7505 and created a fresh `tun0` each time (device index advanced 3 → 4 → 5), confirming clean release.
- **Zero** `Address already in use` / bind / resource-busy errors across reconnects.

Logic also verified in isolation: 0 s when OpenVPN is already gone, ~real exit time otherwise, ~5 s when it never exits (poll cap fallback).