### PR TITLE
build: use WORKDIR instead of cd in OpenVPN builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ FROM alpine:3.24.1 AS openvpn-builder
 ARG OPENVPN_VERSION
 ARG OPENVPN_XOR_PATCH_VERSION
 
+WORKDIR /tmp/openvpn
+
 RUN echo "**** install build dependencies ****" && \
     apk --no-cache --no-progress add \
         autoconf=2.73-r0 \
@@ -74,7 +76,6 @@ RUN echo "**** install build dependencies ****" && \
     mkdir -p /tmp/openvpn && \
     tar xf /tmp/openvpn.tar.gz -C /tmp/openvpn --strip-components=1 && \
     echo "**** apply Tunnelblick XOR patches ${OPENVPN_XOR_PATCH_VERSION} ****" && \
-    cd /tmp/openvpn && \
     PATCH_URLS=$(curl -sf "https://api.github.com/repos/Tunnelblick/Tunnelblick/contents/third_party/sources/openvpn/openvpn-${OPENVPN_XOR_PATCH_VERSION}/patches" \
         | jq -r '.[] | select(.name | contains("xorpatch")) | .download_url' | sort) && \
     [ -n "$PATCH_URLS" ] || { echo "ERROR: No XOR patches found for ${OPENVPN_XOR_PATCH_VERSION}"; exit 1; } && \


### PR DESCRIPTION
## Summary

Fixes code-scanning alert [#701](https://github.com/azinchen/nordvpn/security/code-scanning/701) — **DS-0013** (medium): *"RUN should not be used to change directory: use WORKDIR instead."*

The `openvpn-builder` stage changed into the source tree with `cd /tmp/openvpn` inside the build `RUN`. This replaces it with a `WORKDIR /tmp/openvpn` instruction before the `RUN`. The download/extract steps already use absolute paths (`-o /tmp/openvpn.tar.gz`, `tar -C /tmp/openvpn`), so setting the workdir up front is behaviorally equivalent, and the subsequent `patch`/`autoreconf`/`./configure`/`make` steps run relative to it.

## Testing

Built the stage to confirm the change is sound:

```
docker build --target openvpn-builder .
```

The XOR patches applied, `./configure` + `make` ran in the new `WORKDIR`, the binary was stripped and copied, and the image exported successfully (exit 0). Once merged, scanning will auto-resolve the alert.