### PR TITLE
chore: add .trivyignore (accept DS-0002) and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Only `root/` is COPYed into the image (see Dockerfile). Everything else is
+# excluded from the build context to keep it small and to avoid sending repo
+# metadata, docs and local tooling to the daemon/build.
+
+# Version control & repo metadata
+.git
+.gitignore
+.gitmodules
+.github
+
+# Editor / agent / local tooling
+.claude
+scripts
+
+# Security scanner config (used by CI in the repo, not needed in the image)
+.trivyignore
+
+# Build/compose helpers (not used during image build)
+.dockerignore
+docker-compose.yml
+
+# Documentation & assets
+*.md
+LICENSE
+NordVpn_logo.png
+wiki
+
+# OS / misc noise
+**/.DS_Store
+**/*.log

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Trivy ignore file — suppressions for findings that are accepted by design.
+#
+# DS-0002: "Image user should not be 'root'".
+# This is a VPN gateway container: its s6-overlay init (PID 1) must run as root
+# to manage iptables firewall rules (rebuilt on every reconnect), create/tear
+# down the tun0 device, and edit routing tables (NET_ADMIN + /dev/net/tun).
+# The long-running OpenVPN daemon already drops privileges to the non-root
+# "nordvpn" user (uid/gid 912). A USER directive would break container init, so
+# there is no fix that satisfies this rule without breaking the image.
+AVD-DS-0002
+DS-0002


### PR DESCRIPTION
## Summary

Two related housekeeping files:

### `.trivyignore` — accept DS-0002 ([alert #700](https://github.com/azinchen/nordvpn/security/code-scanning/700))
Suppresses **DS-0002** *"Image user should not be 'root'"* at the source. This is a VPN gateway container: its s6-overlay init (PID 1) must run as root to manage iptables firewall rules (rebuilt on every reconnect), create/tear down `tun0`, and edit routing tables (`NET_ADMIN` + `/dev/net/tun`). The long-running OpenVPN daemon already drops to the non-root `nordvpn` user (uid/gid 912), so there's no `USER` directive that satisfies the rule without breaking init.

The CI scanner (`aquasecurity/trivy-action` in `security-docker.yml`) auto-reads `.trivyignore` from the repo root, so this stops the finding from re-surfacing on future scans. Both `AVD-DS-0002` and `DS-0002` are listed to cover Trivy's ID-format variants.

### `.dockerignore`
The Dockerfile only `COPY`s `root/`, so everything else is excluded from the build context: git metadata, `.github`, `.claude`, `scripts/`, `wiki/`, `docker-compose.yml`, docs/assets (`*.md`, `LICENSE`, `NordVpn_logo.png`), and `.trivyignore` itself.

## Testing
Built the `rootfs-builder` stage with the trimmed context — `COPY root/` succeeds and the build context shrinks to a few KB (exit 0).