### PR TITLE
ci: replace wiki submodule with in-repo folder synced by workflow

### DIFF
--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -1,0 +1,58 @@
+name: Docs - Publish Wiki
+
+on:
+  push:
+    # Publish on every release (tag) push
+    tags: [ '**' ]
+  workflow_dispatch:
+    # Manual publish from any branch or tag
+
+permissions:
+  contents: write  # Required to push to the wiki repository
+
+jobs:
+  publish-wiki:
+    name: 📚 Publish Wiki
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Determine published version
+        id: version
+        run: |
+          # The tag or branch the workflow runs on (push tag or dispatch ref)
+          VERSION="${{ github.ref_name }}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Publishing wiki for version: ${VERSION}"
+
+      - name: Clone wiki repository
+        run: |
+          git clone "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.wiki.git" wiki-repo
+
+      - name: Sync wiki content
+        run: |
+          # Replace/add/delete: make the wiki repo mirror the wiki/ folder exactly
+          rsync -av --delete --exclude '.git' wiki/ wiki-repo/
+
+      - name: Commit and push
+        working-directory: wiki-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No wiki changes - pushing empty marker commit"
+            git commit --allow-empty -m "Publish wiki for ${{ steps.version.outputs.version }} (no content changes)"
+          else
+            git commit -m "Publish wiki for ${{ steps.version.outputs.version }}"
+          fi
+
+          git push origin HEAD:master
+
+      - name: Publish summary
+        run: |
+          echo "✅ Wiki published for version ${{ steps.version.outputs.version }}"
+          echo "   https://github.com/${{ github.repository }}/wiki"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "wiki"]
-	path = wiki
-	url = https://github.com/azinchen/nordvpn.wiki.git

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -1,0 +1,193 @@
+This page describes how the container works internally. Useful for contributors, debugging, and understanding the boot sequence.
+
+## Boot Sequence
+
+The container uses [s6-overlay](https://github.com/just-containers/s6-overlay) for process supervision. Services start in a defined order:
+
+```
+entrypoint (container start)
+  │
+  ├─ init-adduser        Create nordvpn user/group
+  ├─ init-createauth     Write credentials file (0600, owned by nordvpn)
+  ├─ init-createmgmtpwfile  Generate management interface password
+  ├─ init-firewall       Apply iptables rules (depends on entrypoint backend selection)
+  ├─ init-setupcron      Configure cron jobs from RECREATE_VPN_CRON / CHECK_CONNECTION_CRON
+  │
+  ├─ svc-nordvpn         Main OpenVPN service (long-running)
+  └─ svc-cron            Cron daemon (long-running)
+```
+
+## Key Scripts
+
+### `entrypoint` — Backend selection & default-deny
+
+Location: `/usr/local/bin/entrypoint`
+
+1. Detects kernel version
+2. Tests nft and legacy iptables backends by toggling a chain policy (`DROP` ↔ `ACCEPT` on `OUTPUT`)
+3. If preferred backend fails, tests the fallback
+4. If legacy is selected and nft tables already contain rules, flushes nft tables to avoid mixed stacks
+5. Exports selected backends (`IPT`, `IP6T`) to `/run/xt/backend.env`
+6. Sets `INPUT`, `OUTPUT`, `FORWARD` to `DROP` on both IPv4 and IPv6
+7. Allows loopback traffic
+
+Backend preference by kernel:
+
+| Kernel version | Preferred backend | Fallback |
+|---------------|-------------------|----------|
+| ≥ 4.18 | nft (`iptables`) | legacy (`iptables-legacy`) |
+| < 4.18 | legacy (`iptables-legacy`) | nft (`iptables`) |
+
+### `backend-functions` — Shared utilities
+
+Location: `/usr/local/bin/backend-functions`
+
+Sourced by every script. Provides:
+- `run4()` / `run6()` — Execute iptables commands with logging (non-fatal)
+- `run4_critical()` / `run6_critical()` — Execute or sleep forever on failure
+- `is_vpn_connected()` — Checks for tun0 interface
+- `mgmt_cmd()` — Sends authenticated commands to OpenVPN management interface
+- `log()` / `log_error()` / `log_warning()` — Timestamped logging
+- `parse_cron()` — Converts cron expressions to human-readable descriptions
+
+### `vpn-config` — Server selection
+
+Location: `/usr/local/bin/vpn-config`
+
+1. Resolves COUNTRY/CITY/GROUP/TECHNOLOGY to numeric IDs using JSON data files
+2. Builds NordVPN API query URL
+3. Fetches server list using pinned API IPs (no DNS)
+4. Detects specific server hostnames and gives them `load=0`
+5. Sorts by load (multi-location) or keeps API order (single location)
+6. Applies `RANDOM_TOP` if set
+7. Writes selected server's OpenVPN config to disk
+
+For XOR technologies (`openvpn_xor_*`), the script also:
+- Generates multiple `remote` lines from the XOR port list (with `remote-random`)
+- Adds the `scramble obfuscate` directive with the XOR pre-shared key
+- Swaps the `<tls-auth>` block with the XOR-specific key from `tls-auth-xor.pem`
+
+### `svc-nordvpn/run` — OpenVPN launcher
+
+Location: `/etc/s6-overlay/s6-rc.d/svc-nordvpn/run`
+
+1. Calls `vpn-config` to get server configuration
+2. Extracts VPN server IP/port/protocol from the OVPN file
+3. Adds temporary firewall rules in `VPN-SERVER` chain for every `remote` line (XOR configs have multiple ports)
+4. Appends `--data-ciphers` if not already set
+5. Launches OpenVPN with auth, management port, and nordvpn group
+6. Waits for tun0 interface (up to 60 seconds)
+7. Optionally runs network diagnostics
+8. Blocks on OpenVPN process
+
+### `svc-nordvpn/finish` — Cleanup on disconnect
+
+Location: `/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish`
+
+1. Flushes `VPN-SERVER` iptables chain
+2. Sends SIGTERM via management interface (5-second timeout)
+3. Removes OVPN config file
+
+### `vpn-healthcheck` — Connection monitoring
+
+Location: `/usr/local/bin/vpn-healthcheck`
+
+1. Sends HTTP HEAD requests to configured URL(s)
+2. Retries `CHECK_CONNECTION_ATTEMPTS` times with configurable interval
+3. If all fail, calls `vpn-reconnect`
+
+### `vpn-reconnect` — Service restart
+
+Location: `/usr/local/bin/vpn-reconnect`
+
+1. Stops `svc-nordvpn` via s6-rc
+2. Waits 2 seconds
+3. Restarts `svc-nordvpn`
+
+### `network-diagnostic` — Debug tool
+
+Location: `/usr/local/bin/network-diagnostic`
+
+Two modes:
+- `--basic`: Public IP + geolocation only
+- `--full` (default): Complete diagnostics including interfaces, iptables rules, DNS, routes, OpenVPN status
+
+## Data Files
+
+Located in `/usr/local/share/nordvpn/data/`:
+
+| File | Purpose |
+|------|---------|
+| `countries.json` | Country name/code/ID mappings |
+| `groups.json` | Server group definitions |
+| `technologies.json` | VPN technology definitions |
+| `template.ovpn` | Base OpenVPN configuration template |
+| `tls-auth-xor.pem` | XOR-specific TLS pre-shared key (swapped in at runtime for XOR technologies) |
+
+> **Origin of these files:** They are generated from NordVPN's own published material, not maintained by hand. The JSON files (`countries.json`, `groups.json`, `technologies.json`) come from the NordVPN public API (`https://api.nordvpn.com/`), and `template.ovpn` / `tls-auth-xor.pem` are derived from the official OpenVPN configuration files NordVPN distributes (`https://downloads.nordcdn.com/configs/`). The `.ovpn` template keeps NordVPN's settings, embedded CA certificate and `tls-auth` static key, with placeholders (`__PROTOCOL__`, `__REMOTES__`, `__SCRAMBLE__`, `__X509_NAME__`) that `vpn-config` substitutes at runtime. All of these are refreshed automatically by the [`maintenance-updates`](https://github.com/azinchen/nordvpn/actions/workflows/maintenance-updates.yml) GitHub Actions workflow, which opens a pull request when NordVPN changes its certificates, static key, API schema, or recommended options. **Do not edit them by hand** — manual changes are overwritten the next time the workflow runs.
+
+## State Files
+
+| Path | Purpose |
+|------|---------|
+| `/run/xt/backend.env` | Selected iptables backend (IPT, IP6T) |
+| `/run/xt/nordvpn.ovpn` | Current server's OpenVPN config |
+| `/run/xt/auth` | Credentials file (0600) |
+| `/run/xt/mgmt-pw` | Management interface password |
+
+## OpenVPN Management Interface
+
+The container runs an OpenVPN management interface for status queries and graceful shutdown:
+
+| Setting | Value |
+|---------|-------|
+| Host | `127.0.0.1` |
+| Port | `7505` |
+| Auth | Password from `/run/xt/mgmt-pw` |
+
+Used internally by:
+- `vpn-healthcheck` — queries connection state
+- `network-diagnostic` — fetches uptime, remote IP, protocol details
+- `svc-nordvpn/finish` — sends SIGTERM for graceful shutdown
+
+Authentication flow: the `mgmt_cmd()` function connects via netcat, sends the password, waits for the prompt, sends the command, then quits.
+
+## Firewall Build Phases
+
+### Phase 1 — Entrypoint (default-deny)
+
+The `entrypoint` script runs first and:
+- Selects the iptables backend (nft or legacy — see [Firewall Backends](Firewall-Backends))
+- Sets `INPUT`, `OUTPUT`, and `FORWARD` policies to `DROP` on both IPv4 and IPv6
+- Allows loopback traffic (required for inter-process communication)
+
+At this point, **all network traffic is blocked**.
+
+### Phase 2 — init-firewall (allow VPN + exceptions)
+
+The `init-firewall` service then:
+- Detects the Docker network (eth0 subnet and gateway)
+- Enables connection tracking (ESTABLISHED/RELATED)
+- Sets up MASQUERADE on the tun0 (VPN) interface
+- Creates a `VPN-SERVER` chain for temporary per-connection rules
+- Adds NordVPN API IP exceptions (TCP/443 only) from `NORDVPNAPI_IP`
+- If `NETWORK` is set, adds static routes and bidirectional allow rules for those CIDRs
+
+### Phase 3 — svc-nordvpn (per-connection pinhole)
+
+When OpenVPN connects:
+- The VPN server IP/port gets a temporary rule in the `VPN-SERVER` chain
+- For XOR technologies, multiple rules are added (one per `remote` port — see [Technologies](Technologies#multi-port-behavior) for port lists)
+- When the connection drops, `svc-nordvpn/finish` flushes that chain
+
+## Firewall Chain Structure
+
+```
+INPUT chain:  ACCEPT lo → ACCEPT ESTABLISHED,RELATED → [NETWORK CIDRs] → DROP
+OUTPUT chain: ACCEPT lo → ACCEPT ESTABLISHED,RELATED → VPN-SERVER → [NETWORK CIDRs] → ACCEPT tun0 → [NORDVPNAPI IPs] → DROP
+FORWARD chain: ACCEPT ESTABLISHED,RELATED → ACCEPT tun0 → DROP
+
+VPN-SERVER chain: [temporary rules for current VPN server IP:port(s) — one rule per remote line]
+
+NAT/POSTROUTING: MASQUERADE on tun0
+```

--- a/wiki/Automatic-Reconnection.md
+++ b/wiki/Automatic-Reconnection.md
@@ -1,0 +1,86 @@
+The container supports three reconnection mechanisms: scheduled switching, connection failure handling, and health monitoring.
+
+## Scheduled Reconnection
+
+Use `RECREATE_VPN_CRON` to periodically switch to a different server. This uses standard cron syntax.
+
+```bash
+# Reconnect every 6 hours at minute 0
+-e RECREATE_VPN_CRON="0 */6 * * *"
+
+# Reconnect daily at 3 AM
+-e RECREATE_VPN_CRON="0 3 * * *"
+
+# Reconnect every 4 hours
+-e RECREATE_VPN_CRON="0 */4 * * *"
+```
+
+When triggered, the cron job stops the `svc-nordvpn` service, which causes it to restart automatically. On restart, `vpn-config` re-fetches the server list and selects a new server based on current load.
+
+## Connection Failure Handling
+
+Use `OPENVPN_OPTS` to control OpenVPN's behavior when the connection drops:
+
+```bash
+# Force reconnect to different server on connection loss
+-e OPENVPN_OPTS="--pull-filter ignore ping-restart --ping-exit 180"
+
+# Alternative: More aggressive reconnection
+-e OPENVPN_OPTS="--ping 10 --ping-exit 60 --ping-restart 300"
+```
+
+| Option | Effect |
+|--------|--------|
+| `--ping-exit N` | Exit OpenVPN if no ping response in N seconds (triggers service restart → new server) |
+| `--ping-restart N` | Restart connection after N seconds of no pings (stays on same server) |
+| `--pull-filter ignore ping-restart` | Ignore server-pushed ping-restart, use your own value |
+| `--ping N` | Send ping every N seconds |
+
+Using `--ping-exit` causes OpenVPN to **exit** on timeout, which triggers svc-nordvpn to restart and pick a new server. Using `--ping-restart` keeps the same server.
+
+## Connection Health Monitoring
+
+Use the `CHECK_CONNECTION_*` variables for active health probing:
+
+```bash
+-e CHECK_CONNECTION_CRON="*/5 * * * *"
+-e CHECK_CONNECTION_URL="https://1.1.1.1;https://8.8.8.8"
+-e CHECK_CONNECTION_ATTEMPTS=3
+-e CHECK_CONNECTION_ATTEMPT_INTERVAL=10
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHECK_CONNECTION_CRON` | Disabled | Cron schedule for health checks |
+| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (semicolon-separated) |
+| `CHECK_CONNECTION_ATTEMPTS` | `5` | Number of retry attempts |
+| `CHECK_CONNECTION_ATTEMPT_INTERVAL` | `10` | Seconds between retries |
+
+## Docker Health Status
+
+The image ships a Docker [`HEALTHCHECK`](https://docs.docker.com/reference/dockerfile/#healthcheck) that reports the container's health (`healthy` / `unhealthy`) to Docker, Compose `depends_on: condition: service_healthy`, Swarm/Kubernetes, and monitoring or autoheal sidecars. It is **observational only** — it never reconnects. Active recovery is handled separately by `CHECK_CONNECTION_*`, `OPENVPN_OPTS` ping options, and `RECREATE_VPN_CRON`.
+
+It is **opt-in**: while disabled (the default) the probe always reports healthy without testing anything. Set `HEALTHCHECK_ENABLED=true` to activate it.
+
+```bash
+-e HEALTHCHECK_ENABLED=true
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `HEALTHCHECK_ENABLED` | `false` | Enable the Docker `HEALTHCHECK` probe. When disabled, the container always reports healthy. |
+
+When enabled, the probe checks that the `tun0` interface exists and that a single short request to `CHECK_CONNECTION_URL` succeeds. The probe runs every 60s with a 60s start period and 3 retries before the container is marked `unhealthy`; unlike the cron `CHECK_CONNECTION_*` check it performs no retry loop of its own and never triggers a reconnect.
+
+## Recommended Setup
+
+For most users, combining scheduled reconnection with health monitoring provides robust connectivity:
+
+```yaml
+environment:
+  - RECREATE_VPN_CRON=0 */6 * * *           # Switch server every 6 hours
+  - CHECK_CONNECTION_CRON=*/5 * * * *       # Check every 5 minutes
+  - CHECK_CONNECTION_URL=https://1.1.1.1    # Fast, reliable endpoint
+  - CHECK_CONNECTION_ATTEMPTS=3
+  - OPENVPN_OPTS=--ping-exit 180            # Exit if server unresponsive for 3 min
+```

--- a/wiki/Custom-DNS.md
+++ b/wiki/Custom-DNS.md
@@ -1,0 +1,76 @@
+By default, the container uses DNS servers pushed by NordVPN's OpenVPN server (typically `103.86.96.100` and `103.86.99.100`). These are NordVPN's own DNS servers and may apply regional filtering — for example, certain domains may be sinkholed when connected through UK exit nodes.
+
+This page covers how to override the DNS servers used inside the VPN tunnel.
+
+## Method 1: Bind-Mount a Custom `resolv.conf`
+
+The simplest approach. Mount a custom `resolv.conf` file as read-only so OpenVPN's `up.sh` script cannot overwrite it:
+
+**1. Create a `resolv.conf` file:**
+
+```
+nameserver 1.1.1.1
+nameserver 1.0.0.1
+```
+
+**2. Mount it in your compose file:**
+
+```yaml
+services:
+  vpn:
+    volumes:
+      - ./resolv.conf:/etc/resolv.conf:ro
+```
+
+The `:ro` (read-only) flag prevents OpenVPN from overwriting it with server-pushed DNS.
+
+## Method 2: Pull-Filter with Custom DHCP Options
+
+Use OpenVPN's `--pull-filter` to block server-pushed DNS and `--dhcp-option` to inject your own. This lets the container's built-in `up.sh` script write your custom DNS to `/etc/resolv.conf` naturally:
+
+```yaml
+services:
+  vpn:
+    environment:
+      - OPENVPN_OPTS=--pull-filter ignore "dhcp-option DNS" --dhcp-option DNS 1.1.1.1 --dhcp-option DNS 1.0.0.1
+```
+
+**How it works:**
+- `--pull-filter ignore "dhcp-option DNS"` — blocks DNS servers pushed by the NordVPN server
+- `--dhcp-option DNS 1.1.1.1` — injects Cloudflare DNS as a client-side option
+- The `up.sh` script reads these options and writes them to `/etc/resolv.conf`
+
+## Popular DNS Providers
+
+| Provider | Primary | Secondary |
+|----------|---------|-----------|
+| Cloudflare | `1.1.1.1` | `1.0.0.1` |
+| Google | `8.8.8.8` | `8.8.4.4` |
+| Quad9 | `9.9.9.9` | `149.112.112.112` |
+| OpenDNS | `208.67.222.222` | `208.67.220.220` |
+
+## Why Not Docker `dns:`?
+
+Docker's `dns:` option configures an internal resolver (`127.0.0.11`) that forwards to the specified servers. However, in VPN containers with strict firewall rules (kill switch), Docker's internal DNS resolver cannot forward queries through the VPN tunnel, resulting in `connection refused` errors. Use one of the methods above instead.
+
+## Verifying Your DNS Configuration
+
+After the VPN connects, check which DNS servers are active:
+
+```bash
+docker exec vpn cat /etc/resolv.conf
+```
+
+Test resolution:
+
+```bash
+docker exec vpn host example.com
+```
+
+Run the full network diagnostic to see DNS details:
+
+```bash
+docker exec vpn /usr/local/bin/network-diagnostic
+```
+
+The diagnostic output includes a **DNS configuration** section showing the active nameservers and their geolocation.

--- a/wiki/Docker-Compose-Examples.md
+++ b/wiki/Docker-Compose-Examples.md
@@ -1,0 +1,209 @@
+## Simple VPN + Application Setup
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - COUNTRY=United States;CA;38
+      - CITY=New York;Los Angeles;Toronto
+      - RANDOM_TOP=10
+      - RECREATE_VPN_CRON=0 */6 * * *
+      - NETWORK=192.168.1.0/24
+    ports:
+      - "8080:8080"
+      - "3000:3000"
+    restart: unless-stopped
+
+  webapp:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./html:/usr/share/nginx/html:ro
+    restart: unless-stopped
+
+  api-service:
+    image: node:alpine
+    container_name: api-service
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    working_dir: /app
+    volumes:
+      - ./app:/app
+    command: ["npm", "start"]
+    restart: unless-stopped
+```
+
+## Advanced Setup with Local Access
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - COUNTRY=Netherlands;DE;209
+      - CITY=Amsterdam;Berlin;Frankfurt
+      - GROUP=Standard VPN servers
+      - RANDOM_TOP=5
+      - RECREATE_VPN_CRON=0 */4 * * *
+      - CHECK_CONNECTION_CRON=*/5 * * * *
+      - CHECK_CONNECTION_URL=https://1.1.1.1;https://8.8.8.8
+      - NETWORK=192.168.1.0/24;172.20.0.0/16
+      - OPENVPN_OPTS=--mute-replay-warnings --ping-exit 60
+    ports:
+      - "8080:8080"
+      - "3000:3000"
+      - "9000:9000"
+      - "6379:6379"
+    restart: unless-stopped
+
+  webapp:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      vpn:
+        condition: service_healthy
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./web:/usr/share/nginx/html:ro
+    restart: unless-stopped
+
+  api-service:
+    image: node:alpine
+    container_name: api-service
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+      - webapp
+    working_dir: /app
+    volumes:
+      - ./api:/app
+    command: ["npm", "start"]
+    restart: unless-stopped
+
+  redis:
+    image: redis:alpine
+    container_name: redis
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./config/redis:/data
+    restart: unless-stopped
+
+  # Service that DOESN'T use VPN (runs on host network)
+  monitoring:
+    image: grafana/grafana:latest
+    container_name: monitoring
+    network_mode: host
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./config/grafana:/var/lib/grafana
+    restart: unless-stopped
+```
+
+## Web Proxy Setup
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - COUNTRY=CA;38
+      - CITY=Toronto;Montreal
+      - NETWORK=192.168.1.0/24
+    restart: unless-stopped
+
+  app:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    volumes:
+      - ./html:/usr/share/nginx/html
+    restart: unless-stopped
+
+  nginx-proxy:
+    image: nginx:alpine
+    container_name: proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - vpn
+    restart: unless-stopped
+```
+
+## Key Concepts
+
+- **Ports must be published on the VPN container**, not on application containers using `network_mode: "service:vpn"`.
+- Use `depends_on` to ensure the VPN starts before dependent services.
+- Services that should **not** use the VPN can use `network_mode: host` or a separate Docker network.
+- When the VPN container restarts, all dependent containers must also be restarted. See [Updating and Maintenance](Updating-and-Maintenance#why-dependent-containers-must-restart).
+
+## XOR Obfuscation Setup
+
+Use XOR obfuscation to bypass deep packet inspection (DPI) on networks that block standard OpenVPN traffic. See [Technologies](Technologies#xor-obfuscated-openvpn-openvpn_xor_udp--openvpn_xor_tcp) for details.
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    container_name: nordvpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - TECHNOLOGY=openvpn_xor_tcp
+      - GROUP=legacy_obfuscated_servers
+      - COUNTRY=Netherlands;DE
+      - RECREATE_VPN_CRON=0 */6 * * *
+      - CHECK_CONNECTION_CRON=*/5 * * * *
+      - NETWORK=192.168.1.0/24
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  app:
+    image: nginx:alpine
+    container_name: webapp
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+    restart: unless-stopped
+```
+
+> **Note:** `GROUP=legacy_obfuscated_servers` is required — without it, no XOR servers will be returned. Not all countries have obfuscated servers.

--- a/wiki/Docker-Run-Examples.md
+++ b/wiki/Docker-Run-Examples.md
@@ -1,0 +1,69 @@
+## Basic Example
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --device /dev/net/tun \
+           -e USER=service_username \
+           -e PASS=service_password \
+           azinchen/nordvpn
+
+# Run application through VPN
+docker run -d --name app --net=container:vpn nginx
+```
+
+## Advanced Example with Port Mapping
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --device /dev/net/tun \
+           -p 8080:8080 \
+           -p 9091:9091 \
+           -e USER=service_username \
+           -e PASS=service_password \
+           -e COUNTRY="Germany;NL;202" \
+           -e CITY="Amsterdam;6076868;uk2567" \
+           -e GROUP="Standard VPN servers" \
+           -e RANDOM_TOP=3 \
+           -e RECREATE_VPN_CRON="0 */6 * * *" \
+           -e NETWORK=192.168.1.0/24 \
+           azinchen/nordvpn
+
+# Applications using VPN (access via host ports)
+docker run -d --name webapp --net=container:vpn \
+           nginx:alpine
+
+docker run -d --name api-service --net=container:vpn \
+           -v ./app:/app -w /app \
+           node:alpine npm start
+```
+
+## Key Points
+
+- **`--cap-add=NET_ADMIN`** and **`--device /dev/net/tun`** are always required.
+- **Ports** must be published on the VPN container (`-p` on the `vpn` container), not on the application containers.
+- Application containers connect via `--net=container:vpn`.
+- For GitHub Container Registry, replace `azinchen/nordvpn` with `ghcr.io/azinchen/nordvpn`.
+
+## XOR Obfuscation Example
+
+Use XOR obfuscation to bypass deep packet inspection. See [Technologies](Technologies#xor-obfuscated-openvpn-openvpn_xor_udp--openvpn_xor_tcp) for details.
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --device /dev/net/tun \
+           -p 8080:8080 \
+           -e USER=service_username \
+           -e PASS=service_password \
+           -e TECHNOLOGY=openvpn_xor_tcp \
+           -e GROUP=legacy_obfuscated_servers \
+           -e COUNTRY=Netherlands \
+           -e NETWORK=192.168.1.0/24 \
+           azinchen/nordvpn
+
+docker run -d --name app --net=container:vpn nginx
+```
+
+> **Note:** `GROUP=legacy_obfuscated_servers` is required for XOR technologies. Not all countries have obfuscated servers.

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,95 @@
+## Credentials
+
+**Q: Can I use my regular NordVPN email and password?**
+No. You need **service credentials** (a separate username/password) specifically for OpenVPN connections. See [Getting Service Credentials](https://github.com/azinchen/nordvpn#getting-service-credentials).
+
+**Q: Where do I find my service credentials?**
+Log into [Nord Account Dashboard](https://my.nordaccount.com/) → NordVPN → Advanced Settings → Set up NordVPN manually → Service credentials tab.
+
+## Features
+
+**Q: Does this support WireGuard?**
+No. This container uses OpenVPN only. See [Technologies](Technologies#supported-technologies) for the full list of supported values.
+
+The `TECHNOLOGY` variable accepts the following values:
+
+| Value | Description | Requires `GROUP`? |
+|-------|-------------|-------------------|
+| `openvpn_udp` | Standard OpenVPN over UDP (default) | No |
+| `openvpn_tcp` | Standard OpenVPN over TCP | No |
+| `openvpn_xor_udp` | Obfuscated OpenVPN over UDP | Yes — `GROUP=legacy_obfuscated_servers` |
+| `openvpn_xor_tcp` | Obfuscated OpenVPN over TCP | Yes — `GROUP=legacy_obfuscated_servers` |
+| `openvpn_dedicated_udp` | Dedicated IP OpenVPN over UDP | Yes — `GROUP=legacy_dedicated_ip` |
+| `openvpn_dedicated_tcp` | Dedicated IP OpenVPN over TCP | Yes — `GROUP=legacy_dedicated_ip` |
+
+> **Note:** Other OpenVPN technologies listed in the NordVPN API (`openvpn_udp_v6`, `openvpn_tcp_v6`, `openvpn_udp_tls_crypt`, `openvpn_tcp_tls_crypt`) have no servers assigned and will not work. Non-OpenVPN technologies (IKEv2, WireGuard, SOCKS, etc.) are not supported by this container.
+
+**Q: Can I use port forwarding / access services from the internet?**
+No. NordVPN does not support inbound port forwarding. You can only access services from your LAN by publishing ports on the VPN container and setting `NETWORK` to include your LAN CIDR.
+
+**Q: How do I know which server I'm connected to?**
+Check the container logs: `docker logs vpn | grep "Server:"`. Or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
+
+**Q: Can I connect to a specific server?**
+Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. Specific servers get priority with `load=0`.
+
+## Networking
+
+**Q: Why can't my app containers reach my LAN?**
+Set `NETWORK` to include your LAN CIDR (e.g., `-e NETWORK=192.168.1.0/24`). Docker subnets and LAN ranges are not auto-allowed. See [Local Network Access](Local-Network-Access).
+
+**Q: Why do I need to publish ports on the VPN container instead of the app container?**
+Containers using `network_mode: "service:vpn"` share the VPN container's network namespace. They don't have their own network stack, so port publishing only works on the VPN container.
+
+**Q: Does IPv6 work?**
+The container applies an IPv6 firewall (default DROP), but does not route IPv6 through the VPN. To prevent IPv6 leaks, disable it at the daemon or container level. See [IPv6 Configuration](IPv6-Configuration).
+
+## Operations
+
+**Q: Why do my app containers lose network after VPN restarts?**
+Containers sharing the VPN's network namespace reference the old namespace after a restart. You must restart them too. See [Updating and Maintenance](Updating-and-Maintenance#why-dependent-containers-must-restart).
+
+**Q: How often should I reconnect?**
+Every 4–8 hours is common. Use `RECREATE_VPN_CRON` for scheduled switching and `CHECK_CONNECTION_CRON` for health monitoring. See [Automatic Reconnection](Automatic-Reconnection).
+
+**Q: What happens if the VPN drops?**
+The kill switch blocks all traffic except `NETWORK` CIDRs and NordVPN API IPs. If health monitoring is configured, the container will automatically reconnect. See [Security Model](Security-Model#traffic-control--kill-switch).
+
+## Permissions
+
+**Q: I'm getting permission errors on mounted volumes. How do I fix this?**
+The container runs OpenVPN as the `nordvpn` user (UID/GID `912` by default). Set `PUID` and `PGID` to match your host user's UID/GID. See [Permissions](Permissions).
+
+## Compatibility
+
+**Q: Does this work on Raspberry Pi?**
+Yes. The image supports `arm/v6`, `arm/v7`, and `arm64`. Docker pulls the correct architecture automatically.
+
+**Q: Does this work on Synology / QNAP NAS?**
+Generally yes, but some NAS devices have older kernels or limited iptables support. The container auto-detects nft vs legacy backends. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to verify.
+
+**Q: What's the difference between Docker Hub and GHCR images?**
+They are identical. Use whichever registry is more convenient: `azinchen/nordvpn` (Docker Hub) or `ghcr.io/azinchen/nordvpn` (GitHub Container Registry).
+
+## Logs & Messages
+
+**Q: I see `DEPRECATED OPTION: --persist-key option ignored` and `--fast-io option ignored` in the logs. Is something wrong?**
+No. These are harmless, cosmetic notices from newer OpenVPN versions. Both options are set in the bundled `.ovpn` config template; modern OpenVPN no longer needs them (keys are always persisted now, and `--fast-io` was removed), so it simply ignores them and prints the notice. Your connection is unaffected.
+
+**Q: Can I silence these deprecation notices with `OPENVPN_OPTS`?**
+No. They originate from options inside the config file, and OpenVPN has no command-line flag to unset a config option (`--pull-filter` only affects options *pushed by the server*). The only way to hide them would be lowering verbosity with `--verb 0`/`--verb 1`, but that also suppresses useful connection status and error messages, so it is not recommended. Leave the notices as-is — they are safe to ignore.
+
+**Q: I see `DEPRECATED OPTION: --cipher set to 'AES-256-CBC' but missing in --data-ciphers (DEFAULT). OpenVPN ignores --cipher for cipher negotiations.` in the logs. Is something wrong?**
+No. This is a cosmetic notice. NordVPN's `.ovpn` template sets `cipher AES-256-CBC`, but modern OpenVPN (2.5+) negotiates the data cipher with the server instead of using the legacy `--cipher` value. The server selects a strong cipher (you'll see `Data Channel: cipher 'AES-256-GCM'` later in the log), so the connection is unaffected and the warning can be safely ignored.
+
+**Q: How do I disable the `--cipher ... missing in --data-ciphers` warning?**
+Set `--data-ciphers` via `OPENVPN_OPTS` and include the legacy `AES-256-CBC` cipher so the value from the config is no longer reported as missing. For example:
+
+```yaml
+environment:
+  - OPENVPN_OPTS=--data-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC
+```
+
+Keep `AES-256-GCM` (and optionally the others) first so the strong cipher is still preferred during negotiation; appending `AES-256-CBC` only suppresses the notice. This is purely cosmetic — the negotiated cipher does not change.
+
+

--- a/wiki/Firewall-Backends.md
+++ b/wiki/Firewall-Backends.md
@@ -1,0 +1,30 @@
+This image ships **both** `iptables` (nft-backed) and `iptables-legacy` (xtables). At runtime, the entrypoint automatically selects a working backend.
+
+## Selection Logic
+
+| Kernel version | Preferred backend | Fallback |
+|---------------|-------------------|----------|
+| ≥ 4.18 (new) | **nft** (`iptables`) | legacy (`iptables-legacy`) |
+| < 4.18 (old, e.g. 4.4) | **legacy** (`iptables-legacy`) | nft (`iptables`) |
+
+## Log Output
+
+On newer kernels:
+```
+[ENTRYPOINT] Kernel: 6.8.0-xx
+[ENTRYPOINT] Using IPv4 backend: iptables
+```
+
+On older systems:
+```
+[ENTRYPOINT] Kernel: 4.4.0-xxx
+[ENTRYPOINT] Using IPv4 backend: iptables-legacy
+```
+
+## Why This Matters
+
+- Some hosts (especially older NAS devices, VMs, or WSL) don't support nftables properly
+- Docker Desktop on macOS/Windows uses a Linux VM whose kernel may behave differently
+- Mixing nft and legacy rules in the same namespace causes unpredictable behavior — the entrypoint prevents this
+
+No manual configuration is needed. The container handles backend selection automatically.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,41 @@
+# NordVPN OpenVPN Docker Container — Wiki
+
+Welcome to the wiki for the **NordVPN OpenVPN Docker Container**. This wiki provides detailed configuration guides, examples, and troubleshooting information beyond what's covered in the [README](https://github.com/azinchen/nordvpn#readme).
+
+> **Looking for WireGuard?** This has a sibling project, [**azinchen/nordvpn-wg**](https://github.com/azinchen/nordvpn-wg) — the same auto-routing NordVPN container over WireGuard (NordLynx). See its [wiki](https://github.com/azinchen/nordvpn-wg/wiki) for WireGuard-specific guides.
+
+## Getting Started
+
+If you're new, start with the [README](https://github.com/azinchen/nordvpn#readme) for a quick-start guide, then explore the pages below for advanced configuration.
+
+## Pages
+
+### Configuration
+- **[Server Selection](Server-Selection)** — Filter by country, city, group, or specific server hostname
+- **[Server Groups](Server-Groups)** — Specialty server groups: Double VPN, Onion Over VPN, P2P, obfuscated, dedicated IP, and regional filters
+- **[Technologies](Technologies)** — Supported OpenVPN technologies including XOR obfuscation
+- **[IPv6 Configuration](IPv6-Configuration)** — Prevent IPv6 leaks with daemon, container, or host-level options
+- **[Automatic Reconnection](Automatic-Reconnection)** — Scheduled reconnection, failure handling, and health monitoring
+- **[Local Network Access](Local-Network-Access)** — Allow LAN and inter-container traffic through the firewall
+- **[VPN Gateway Mode](VPN-Gateway-Mode)** — Route other containers' traffic out through the tunnel with `FORWARD_FROM`
+- **[OpenVPN Options](OpenVPN-Options)** — Custom OpenVPN flags, default ciphers, and reconnection tuning
+- **[Custom DNS](Custom-DNS)** — Override NordVPN's DNS servers with custom ones (Cloudflare, Google, etc.)
+- **[Permissions](Permissions)** — PUID/PGID configuration for volume permissions
+
+### Security
+- **[Security Model](Security-Model)** — Kill switch behavior, rule precedence, and network access control
+- **[Firewall Backends](Firewall-Backends)** — How nftables vs iptables-legacy selection works at runtime
+
+### Examples
+- **[Docker Compose Examples](Docker-Compose-Examples)** — Simple, advanced, and web-proxy compose setups
+- **[Docker Run Examples](Docker-Run-Examples)** — Basic and advanced `docker run` usage
+
+### Operations
+- **[Updating and Maintenance](Updating-and-Maintenance)** — How to update the VPN container and restart dependent services
+- **[Troubleshooting](Troubleshooting)** — Common problems, diagnostic tools, and log reading tips
+- **[Network Diagnostics Guide](Network-Diagnostics-Guide)** — Using the built-in diagnostic tool and interpreting output
+
+### Reference
+- **[FAQ](FAQ)** — Frequently asked questions
+- **[Supported Platforms](Supported-Platforms)** — Available architectures and Raspberry Pi notes
+- **[Architecture and Internals](Architecture-and-Internals)** — How the s6-overlay stages, scripts, and firewall work under the hood

--- a/wiki/IPv6-Configuration.md
+++ b/wiki/IPv6-Configuration.md
@@ -1,0 +1,48 @@
+This image **applies an IPv6 firewall** (when `ip6tables` is available and IPv6 is enabled): `INPUT`/`FORWARD`/`OUTPUT` default to `DROP`. It does **not** change IPv6 sysctls from inside the container (many environments mount `/proc/sys` read-only).
+
+If your Docker runtime assigns IPv6 addresses and you want to avoid IPv6 leaks, choose **one** of the following options.
+
+## Option A — Disable IPv6 for the Docker daemon/network (recommended)
+
+- **Daemon-wide:** set `"ipv6": false` in Docker's `daemon.json` and restart Docker.
+- **Per-network:** create the network with `--ipv6=false`.
+
+## Option B — Disable IPv6 per container via runtime sysctls
+
+Pass sysctls at **run** time (works even when `/proc/sys` is read-only inside the container):
+
+```bash
+docker run -d --cap-add=NET_ADMIN --device /dev/net/tun --name vpn \
+           --sysctl net.ipv6.conf.all.disable_ipv6=1 \
+           --sysctl net.ipv6.conf.default.disable_ipv6=1 \
+           --sysctl net.ipv6.conf.eth0.disable_ipv6=1 \
+           azinchen/nordvpn
+```
+
+**docker-compose:**
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: "1"
+      net.ipv6.conf.default.disable_ipv6: "1"
+      net.ipv6.conf.eth0.disable_ipv6: "1"
+```
+
+## Option C — Disable IPv6 on the host
+
+Use host sysctls or OS network settings to turn off IPv6 globally.
+
+## How to Verify IPv6 Is Off
+
+Inside the container:
+
+```bash
+cat /proc/net/if_inet6            # no output means no IPv6 addresses
+ip -6 addr show dev eth0          # should show "Device not found" or no inet6 lines
+ip6tables -S 2>/dev/null || true  # may be empty/unavailable
+```
+
+> **Note:** If your environment leaves IPv6 **enabled**, IPv6 traffic may bypass the IPv4 firewall. Use one of the options above to disable IPv6 at runtime.

--- a/wiki/Local-Network-Access.md
+++ b/wiki/Local-Network-Access.md
@@ -1,0 +1,78 @@
+By default, all traffic is routed through the VPN. To allow access to local services, your LAN, or inter-container networks, you must explicitly define them with the `NETWORK` variable.
+
+## Finding Your Local Network
+
+```bash
+ip route | awk '!/ (docker0|br-)/ && /src/ {print $1}'
+```
+
+## Configuration
+
+```bash
+docker run -d --cap-add=NET_ADMIN --device /dev/net/tun \
+           -e NETWORK=192.168.1.0/24 \
+           -e USER=service_username -e PASS=service_password \
+           azinchen/nordvpn
+```
+
+Multiple CIDRs are semicolon-separated:
+
+```bash
+-e NETWORK="192.168.1.0/24;172.20.0.0/16;10.0.0.0/8"
+```
+
+## What `NETWORK` Does
+
+When `NETWORK` is set, the `init-firewall` script:
+
+1. Adds a **static route** for each CIDR via the default gateway (so traffic bypasses the VPN tunnel)
+2. Adds **bidirectional iptables rules** allowing traffic to/from those CIDRs
+3. These rules apply **regardless of VPN state** — they remain active even if the VPN drops
+
+## Important Notes
+
+- **Docker subnets are NOT auto-allowed.** If containers sharing the VPN namespace need to talk to each other or to services on your LAN/host, include those CIDRs in `NETWORK`.
+- **Only CIDRs (IP ranges) are supported**, not domain names.
+- **Keep `NETWORK` as narrow as possible.** Broad CIDRs weaken the kill switch since traffic to those destinations is always allowed.
+
+## Common Scenarios
+
+### Access services on your LAN
+```bash
+-e NETWORK=192.168.1.0/24
+```
+
+### Allow Docker inter-container communication
+```bash
+-e NETWORK="192.168.1.0/24;172.20.0.0/16"
+```
+
+### Multiple network segments
+```bash
+-e NETWORK="10.0.0.0/8;172.16.0.0/12;192.168.0.0/16"
+```
+
+## Docker Compose Example
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - NETWORK=192.168.1.0/24;172.20.0.0/16
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+  app:
+    image: nginx:alpine
+    network_mode: "service:vpn"
+    depends_on:
+      - vpn
+```

--- a/wiki/Network-Diagnostics-Guide.md
+++ b/wiki/Network-Diagnostics-Guide.md
@@ -1,0 +1,125 @@
+The container includes a built-in diagnostic tool at `/usr/local/bin/network-diagnostic` that provides comprehensive network and VPN status information.
+
+## Running Diagnostics
+
+### Automatic (on every connection)
+
+```bash
+-e NETWORK_DIAGNOSTIC_ENABLED=true
+```
+
+### Manual
+
+```bash
+# Full diagnostics
+docker exec vpn /usr/local/bin/network-diagnostic
+
+# Quick IP + location check only
+docker exec vpn /usr/local/bin/network-diagnostic --basic
+```
+
+## Modes
+
+### `--basic` Mode
+
+Outputs a single line:
+
+```
+Public IP address 203.0.113.42, location Amsterdam NL
+```
+
+Returns exit code 0 on success, 1 if the public IP couldn't be determined.
+
+### `--full` Mode (default)
+
+Produces a comprehensive report covering all sections below.
+
+## Output Sections (Full Mode)
+
+### 1. Header & VPN Status
+
+```
+═══════════════════════════════════════════
+  OpenVPN DIAG — 2026-03-22 16:30:00 UTC
+  VPN: CONNECTED | iptables: nft | Kernel: 6.8.0-45
+═══════════════════════════════════════════
+```
+
+### 2. Device & Connection Info
+
+- Interface name (tun0/tap0)
+- Common name, local/remote ifconfig addresses
+- Route gateway
+- Connected peer IP:port
+- Protocol (UDP/TCP)
+- Local port
+- Connection uptime (e.g., `2d 14:30:45`)
+
+### 3. System Network State
+
+- `ip addr` — all interface addresses
+- `ip link` — link states
+- `ip route` — routing table
+- `ip rule` — policy routing rules
+
+### 4. Firewall Rules
+
+- Full iptables/ip6tables filter and NAT table dumps
+- Detects whether nft or legacy backend is in use
+
+### 5. Public IP & Geolocation
+
+- JSON output from IP lookup service
+- Shows IP, city, country, ISP/org
+
+### 6. DNS Configuration
+
+- Contents of `/etc/resolv.conf` or `resolvectl` output
+- For each nameserver: geolocation lookup (city, country, organization)
+- Resolver identity via `whoami.cloudflare` or `hostname.bind` queries
+
+### 7. Connectivity Tests
+
+- IPv4/IPv6 ping tests
+- Traceroute to public test IP
+- Route validation verdicts
+
+## IP Resolution Fallback
+
+The diagnostic tool uses a 2-tier fallback to determine your public IP:
+
+| Tier | Service | What it returns |
+|------|---------|-----------------|
+| 1 | `ipinfo.io/json` | IP, city, country (single JSON request) |
+| 2 | `ifconfig.co` + `/city` + `/country-iso` | IP, city, country (separate requests) |
+
+Each request has a 4-second timeout. Tier 2 is only tried if tier 1 fails.
+
+## Management Interface Queries
+
+The diagnostic tool queries OpenVPN's management interface (localhost:7505) for live connection data:
+
+| Command | Data returned |
+|---------|--------------|
+| `status` | Connected clients, traffic stats |
+| `state` | Connection timestamp, remote IP, port, protocol |
+
+From the `state` response, the tool calculates connection uptime and extracts the VPN server details.
+
+## Example Output (Basic)
+
+```
+Public IP address 185.93.1.42, location Zurich CH
+```
+
+## Using Diagnostics for Troubleshooting
+
+| Symptom | What to check in diagnostic output |
+|---------|------|
+| Wrong country | Public IP geolocation — confirms which exit you're using |
+| DNS leaks | DNS section — nameservers should be VPN-provided (10.x.x.x) |
+| No connectivity | VPN status line — check if connected, verify tun0 exists |
+| Slow speeds | Connection details — check protocol (UDP vs TCP), server load |
+| Firewall issues | Iptables dump — look for missing ACCEPT rules on tun0 |
+
+See also: [Troubleshooting](Troubleshooting)

--- a/wiki/OpenVPN-Options.md
+++ b/wiki/OpenVPN-Options.md
@@ -1,0 +1,95 @@
+The `OPENVPN_OPTS` environment variable lets you pass additional flags directly to the OpenVPN process. This page documents the default behavior and commonly useful options.
+
+## Default Cipher Configuration
+
+The container automatically appends `--data-ciphers` if it's not already present in your `OPENVPN_OPTS`:
+
+```
+--data-ciphers AES-256-CBC:AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305
+```
+
+This prevents OpenVPN cipher deprecation warnings. To override, specify your own `--data-ciphers` in `OPENVPN_OPTS` — the container won't add the default if the flag is already present.
+
+## How OpenVPN Is Launched
+
+The full command assembled by the container:
+
+```
+openvpn --group nordvpn \
+        --config /run/xt/nordvpn.ovpn \
+        --auth-user-pass /run/xt/auth \
+        --auth-nocache \
+        --management 127.0.0.1 7505 /run/xt/mgmt-pw \
+        $OPENVPN_OPTS
+```
+
+Your `OPENVPN_OPTS` flags are appended at the end, so they can override settings from the `.ovpn` config.
+
+## Commonly Useful Options
+
+### Reconnection Control
+
+| Option | Effect |
+|--------|--------|
+| `--ping-exit N` | Exit OpenVPN after N seconds with no ping response. Triggers a service restart → new server. |
+| `--ping-restart N` | Restart the connection after N seconds of no pings (stays on same server). |
+| `--pull-filter ignore ping-restart` | Ignore server-pushed ping-restart value. Use with your own `--ping-exit`. |
+| `--ping N` | Send a ping every N seconds. |
+
+**Recommended for aggressive reconnection:**
+```bash
+-e OPENVPN_OPTS="--pull-filter ignore ping-restart --ping-exit 180"
+```
+
+This ignores the server's ping-restart setting and exits after 3 minutes of silence, causing the container to pick a new server.
+
+### Logging & Debugging
+
+| Option | Effect |
+|--------|--------|
+| `--mute-replay-warnings` | Suppress replay warning messages (common with UDP). |
+| `--verb N` | Set verbosity level (0–11). Default is 3. Use 4–5 for debug. |
+| `--log /dev/stdout` | Explicit stdout logging (usually default). |
+
+### Protocol & Connection
+
+| Option | Effect |
+|--------|--------|
+| `--connect-retry N` | Wait N seconds between connection attempts. |
+| `--connect-retry-max N` | Maximum number of retries. |
+| `--resolv-retry N` | Retry DNS resolution for N seconds (or `infinite`). |
+| `--keepalive N M` | Shortcut for `--ping N --ping-restart M`. |
+
+### Security
+
+| Option | Effect |
+|--------|--------|
+| `--data-ciphers LIST` | Override the cipher negotiation list. Colon-separated. |
+| `--cipher ALG` | Set the fallback cipher (deprecated in favor of `--data-ciphers`). |
+| `--tls-cipher LIST` | Restrict TLS control channel ciphers. |
+| `--auth ALG` | HMAC authentication algorithm (e.g., `SHA256`). |
+
+## Examples
+
+```bash
+# Aggressive reconnection + suppress warnings
+-e OPENVPN_OPTS="--mute-replay-warnings --ping-exit 180"
+
+# Debug logging
+-e OPENVPN_OPTS="--verb 5"
+
+# Custom cipher list
+-e OPENVPN_OPTS="--data-ciphers AES-256-GCM:CHACHA20-POLY1305"
+
+# Combined: quiet + fast reconnect
+-e OPENVPN_OPTS="--mute-replay-warnings --pull-filter ignore ping-restart --ping-exit 60"
+```
+
+## Docker Compose
+
+```yaml
+environment:
+  - OPENVPN_OPTS=--mute-replay-warnings --ping-exit 180
+```
+
+> **Note:** Do not quote the value in compose `environment:` list syntax. Multiple flags are space-separated as a single string.

--- a/wiki/Permissions.md
+++ b/wiki/Permissions.md
@@ -1,0 +1,45 @@
+The container runs OpenVPN as a dedicated `nordvpn` user and group. You can control the UID and GID of this user with environment variables.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PUID` | `912` | User ID for the `nordvpn` user |
+| `PGID` | `912` | Group ID for the `nordvpn` group |
+
+## When You Need This
+
+If you mount host volumes into containers that share the VPN's network namespace, OpenVPN (running as UID 912) may not have permission to read/write those files. Setting `PUID` and `PGID` to match your host user avoids permission issues.
+
+## Finding Your Host UID/GID
+
+```bash
+id -u    # your UID
+id -g    # your GID
+```
+
+## Usage
+
+```bash
+docker run -d --cap-add=NET_ADMIN --device /dev/net/tun \
+           -e USER=service_username -e PASS=service_password \
+           -e PUID=1000 -e PGID=1000 \
+           azinchen/nordvpn
+```
+
+### Docker Compose
+
+```yaml
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - PUID=1000
+      - PGID=1000
+```

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -1,0 +1,39 @@
+This page describes the container's firewall behavior, kill switch, and network access control in detail.
+
+## Traffic Control & Kill Switch
+
+- **Default-deny (egress):** All outbound traffic is blocked unless it goes through the VPN interface, matches `NETWORK` (CIDRs you define), or is directed to NordVPN's API.
+- **Bootstrap (pre-VPN):** DNS egress is **blocked**. The container contacts NordVPN's API via **pinned IP addresses** from `NORDVPNAPI_IP` to select a server (no DNS queries before the tunnel is up).
+- **Kill switch:** If the VPN drops, traffic remains blocked **except** for destinations within your `NETWORK` CIDRs (e.g., local/LAN ranges you explicitly allowed) and to NordVPN's API.
+- **Container routing:** Containers using `network_mode: "service:vpn"` share the VPN container's network namespace and inherit these policies.
+- **Inbound (local/LAN only):** No connections from the host or LAN reach the stack **unless you publish ports on the VPN container**. **Public inbound via NordVPN is not supported** (no port forwarding).
+
+## Network Access Control (Exceptions)
+
+- **Local/LAN access (bidirectional, explicit):** Set `NETWORK=192.168.1.0/24` (semicolon-separated CIDRs supported) to allow access to those subnets **regardless of VPN status**.
+- **No domain names allowed:** Use IPs in `NETWORK` for any non-VPN access you require.
+
+## Rule Precedence
+
+1. **Bootstrap-only (when VPN is down & before first connect):** Allow HTTPS only to the **NordVPN API IPs from `NORDVPNAPI_IP`** used by the image's bootstrap script.
+2. **Exceptions:** If destination matches `NETWORK` (CIDR), allow (bypass/LAN), regardless of VPN state.
+3. **VPN path:** If VPN is **up** and traffic is not an exception, allow only via the VPN interface.
+4. **Default-deny:** Otherwise, block.
+
+## Security Notes
+
+### Kill Switch Limitations
+
+Because `NETWORK` remains open when the VPN is down, this is **not a strict kill switch** if you include broad CIDRs. Keep `NETWORK` as narrow as possible (e.g., just your LAN / management subnets).
+
+**Warning:** Setting `NETWORK=0.0.0.0/0` effectively disables the kill switch entirely — all traffic will bypass the VPN.
+
+### Credential Exposure
+
+Credentials passed via `USER` and `PASS` environment variables are:
+- Visible via `docker inspect` on the container
+- Visible in the process environment
+
+To reduce exposure:
+- Use a `.env` file with `env_file:` in Docker Compose (keeps credentials out of `docker-compose.yml`)
+- Avoid passing credentials directly on the `docker run` command line (visible in process listings)

--- a/wiki/Server-Groups.md
+++ b/wiki/Server-Groups.md
@@ -1,0 +1,205 @@
+The `GROUP` environment variable filters the NordVPN server fleet by specialty. Each group is a separate set of servers with different capabilities. Only **one** group can be set at a time.
+
+## Quick Reference
+
+| Group | Identifier | Compatible Technologies | Availability |
+|-------|-----------|------------------------|--------------|
+| Standard VPN servers | `legacy_standard` | `openvpn_udp`, `openvpn_tcp` | All countries |
+| P2P | `legacy_p2p` | `openvpn_udp`, `openvpn_tcp` | Most countries |
+| Double VPN | `legacy_double_vpn` | `openvpn_udp`, `openvpn_tcp` | Limited country pairs |
+| Onion Over VPN | `legacy_onion_over_vpn` | `openvpn_udp`, `openvpn_tcp` | Very limited (NL, SE, CH) |
+| Obfuscated Servers | `legacy_obfuscated_servers` | `openvpn_xor_udp`, `openvpn_xor_tcp` | Many countries |
+| Dedicated IP | `legacy_dedicated_ip` | `openvpn_dedicated_udp`, `openvpn_dedicated_tcp` | Subscription-dependent |
+| Anti DDoS | `legacy_anti_ddos` | `openvpn_udp`, `openvpn_tcp` | Limited |
+| Europe | `europe` | `openvpn_udp`, `openvpn_tcp` | Regional |
+| The Americas | `the_americas` | `openvpn_udp`, `openvpn_tcp` | Regional |
+| Asia Pacific | `asia_pacific` | `openvpn_udp`, `openvpn_tcp` | Regional |
+| Africa, the Middle East and India | `africa_the_middle_east_and_india` | `openvpn_udp`, `openvpn_tcp` | Regional |
+
+You can also use the human-readable names (e.g., `GROUP=Double VPN`) or numeric IDs. The full list is in [GROUPS.md](https://github.com/azinchen/nordvpn/blob/master/GROUPS.md).
+
+When `GROUP` is not set, the API returns servers from the default recommended pool (equivalent to `legacy_standard`).
+
+## Standard VPN Servers (`legacy_standard`)
+
+The default NordVPN fleet. General-purpose servers suitable for everyday use.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  # GROUP not needed — this is the default
+  - COUNTRY=United States
+```
+
+Available in all countries and cities. This is what you get when `GROUP` is omitted.
+
+## P2P (`legacy_p2p`)
+
+Servers optimized for peer-to-peer traffic. These allow the incoming connections that BitTorrent and other P2P protocols require.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=legacy_p2p
+  - COUNTRY=Netherlands
+```
+
+Use when torrenting or file sharing. Available in most countries, though some countries where P2P is restricted by law may not have P2P servers.
+
+## Double VPN (`legacy_double_vpn`)
+
+Traffic is encrypted twice and routed through two VPN servers in different countries. The entry server re-encrypts your traffic and forwards it to the exit server.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=legacy_double_vpn
+```
+
+Server names show both countries (e.g., `ca-us75` = Canada entry → United States exit). You can filter by `COUNTRY` to select the exit country, but only pre-defined country pairs are available.
+
+### When to use
+
+- Maximum privacy requirements (journalism, activism, whistleblowing)
+- When you need two layers of encryption
+- When you want your traffic to pass through two jurisdictions
+
+### Trade-offs
+
+- Higher latency than standard servers (traffic traverses two hops)
+- Lower throughput due to double encryption
+- Not compatible with P2P traffic
+
+## Onion Over VPN (`legacy_onion_over_vpn`)
+
+The VPN server routes your outbound traffic into the Tor network. No local Tor client is needed.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=legacy_onion_over_vpn
+```
+
+Available in very few locations (Netherlands, Sweden, Switzerland at time of writing).
+
+### When to use
+
+- Accessing `.onion` sites without installing Tor
+- Adding a VPN layer before Tor for extra anonymity
+- When you want your ISP to see only VPN traffic, not Tor traffic
+
+### Important: DNS configuration
+
+**Do not override DNS** when using Onion Over VPN. The server pushes NordVPN's own DNS servers (`103.86.96.100`, `103.86.99.100`) which route DNS queries through the Tor network. If you override DNS with external resolvers (e.g., Cloudflare `1.1.1.1`), DNS queries will fail because Tor only carries TCP traffic and standard DNS uses UDP.
+
+```yaml
+# CORRECT — let the server push its own DNS
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=legacy_onion_over_vpn
+  - OPENVPN_OPTS=--mute-replay-warnings --ping-exit 60
+
+# WRONG — this will break DNS resolution
+environment:
+  - OPENVPN_OPTS=--pull-filter ignore "dhcp-option DNS" --dhcp-option DNS 1.1.1.1
+```
+
+### Trade-offs
+
+- Significantly slower than standard or Double VPN (Tor adds multiple hops)
+- Not compatible with P2P traffic
+- Some websites block Tor exit nodes
+
+## Obfuscated Servers (`legacy_obfuscated_servers`)
+
+Servers that support XOR scrambling to disguise OpenVPN traffic, evading deep packet inspection (DPI).
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_xor_tcp
+  - GROUP=legacy_obfuscated_servers
+  - COUNTRY=United Kingdom
+```
+
+**Requires** an XOR technology (`openvpn_xor_udp` or `openvpn_xor_tcp`). Standard OpenVPN technologies will return no servers from this group.
+
+See [Technologies](Technologies#xor-obfuscated-openvpn-openvpn_xor_udp--openvpn_xor_tcp) for XOR-specific details including multi-port behavior and custom port selection.
+
+## Dedicated IP (`legacy_dedicated_ip`)
+
+For NordVPN accounts with the [Dedicated IP add-on](https://nordvpn.com/features/dedicated-ip/). Provides a static IP address assigned exclusively to your account.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_dedicated_udp
+  - GROUP=legacy_dedicated_ip
+```
+
+**Requires** a dedicated technology (`openvpn_dedicated_udp` or `openvpn_dedicated_tcp`). The API returns Dedicated IP servers regardless of your subscription status, but you need an active Dedicated IP add-on for your NordVPN account to successfully authenticate and use these servers.
+
+### When to use
+
+- IP whitelisting for remote access
+- Services that block shared VPN IP addresses
+- When you need a consistent public IP
+
+## Anti DDoS (`legacy_anti_ddos`)
+
+Servers with DDoS protection.
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=legacy_anti_ddos
+```
+
+Useful for gaming or hosting services exposed through the VPN. This group may have limited server availability.
+
+## Regional Groups
+
+Broad geographic filters that return servers from an entire region rather than a specific country.
+
+| Group | Identifier |
+|-------|-----------|
+| Europe | `europe` |
+| The Americas | `the_americas` |
+| Asia Pacific | `asia_pacific` |
+| Africa, the Middle East and India | `africa_the_middle_east_and_india` |
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp
+  - GROUP=europe
+  - RANDOM_TOP=10
+```
+
+Use when you don't need a specific country — just a region. These work with standard OpenVPN technologies.
+
+## Combining with Other Parameters
+
+`GROUP` is sent to the NordVPN API as an AND filter alongside other parameters. All filters must match for a server to be returned.
+
+| Parameter | Combines with `GROUP`? | Notes |
+|-----------|----------------------|-------|
+| `COUNTRY` | Yes | Servers must match both group and country |
+| `CITY` | Yes | Servers must match both group and city |
+| `TECHNOLOGY` | Yes | Some groups **require** specific technologies (see table above) |
+| `RANDOM_TOP` | Yes | Applied after filtering — picks randomly from top N results |
+| `PORT` | Yes | Overrides the default port for the selected technology |
+
+### Restrictions
+
+- **One group at a time.** The API accepts a single group filter. You cannot combine `legacy_p2p` with `legacy_double_vpn`, for example.
+- **Technology pairing matters.** Obfuscated and Dedicated groups require their matching technologies. Standard groups work with `openvpn_udp` or `openvpn_tcp`.
+- **Empty results.** If the combination of `GROUP` + `COUNTRY` + `TECHNOLOGY` has no matching servers, the container falls back to default recommended servers (without the group filter).
+
+## Legacy and Internal Groups
+
+The NordVPN API also lists groups that are **not useful** for this container:
+
+| Group | Reason |
+|-------|--------|
+| `legacy_ultra_fast_tv` (ID 5) | Legacy streaming group — few or no servers |
+| `legacy_netflix_usa` (ID 13) | Legacy streaming group — few or no servers |
+| `legacy_socks5_proxy` (ID 245) | SOCKS5 protocol — not supported by this container |
+| `anycast-dns`, `geo_dns`, `grafana`, `kapacitor`, `fastnetmon` | NordVPN internal infrastructure |

--- a/wiki/Server-Selection.md
+++ b/wiki/Server-Selection.md
@@ -1,0 +1,73 @@
+Filter NordVPN servers using location and server criteria.
+
+## Example
+
+```bash
+docker run -d --cap-add=NET_ADMIN --device /dev/net/tun \
+           -e USER=service_username -e PASS=service_password \
+           -e TECHNOLOGY=openvpn_udp \
+           -e COUNTRY="United States;CA;153" \
+           -e CITY="New York;2619989;es1234" \
+           -e GROUP="Standard VPN servers" \
+           -e RANDOM_TOP=5 \
+           azinchen/nordvpn
+```
+
+## Location Specification
+
+| Filter | Accepted formats | Examples |
+|--------|-----------------|----------|
+| **COUNTRY** | Name, 2-letter code, or numeric ID | `United States`, `US`, `228` |
+| **CITY** | Name or numeric ID | `New York`, `8971718` |
+| **Specific server** | Hostname (in COUNTRY or CITY) | `es1234`, `uk2567` |
+
+Multiple values are semicolon-separated: `COUNTRY="United States;CA;228"`
+
+### Specific Server Hostname Format
+
+To connect to a specific NordVPN server, use its short hostname. The format is:
+
+```
+<2-letter country code><server number>
+```
+
+**Pattern:** Exactly 2 letters followed by 1 or more digits (case-insensitive).
+
+| Input | Resolved hostname | How it works |
+|-------|------------------|---------------|
+| `us1` | `us1.nordvpn.com` | US server #1 |
+| `DE456` | `de456.nordvpn.com` | Germany server #456 |
+| `gb42` | `gb42.nordvpn.com` | UK server #42 |
+
+Specific servers are:
+- Resolved via DNS to their IP address
+- Given `load=0` so they always appear first in the server list
+- Placed in either `COUNTRY` or `CITY` — both work the same way
+
+**Invalid formats** (will be treated as country/city names): `usa1` (3 letters), `u1` (1 letter), `us` (no digits).
+
+Reference lists:
+- [Countries](https://github.com/azinchen/nordvpn/blob/master/COUNTRIES.md)
+- [Cities](https://github.com/azinchen/nordvpn/blob/master/CITIES.md)
+- [Groups](https://github.com/azinchen/nordvpn/blob/master/GROUPS.md)
+- [Technologies](https://github.com/azinchen/nordvpn/blob/master/TECHNOLOGIES.md)
+
+## Selection Behavior
+
+- **Specific servers** (e.g., `es1234`): Placed at the top of the list with `load=0`
+- **Multiple locations**: Combined and sorted by server load (lowest first)
+- **Single location**: Keeps NordVPN's recommended order
+- **RANDOM_TOP=N**: After filtering and sorting, randomly picks from the top N servers
+
+## Technology-Specific Groups
+
+Some technologies require a specific `GROUP` to return servers from the API:
+
+| Technology | Required `GROUP` |
+|------------|-----------------|
+| `openvpn_xor_udp` / `openvpn_xor_tcp` | `legacy_obfuscated_servers` |
+| `openvpn_dedicated_udp` / `openvpn_dedicated_tcp` | `legacy_dedicated_ip` |
+
+Without the matching group, the API returns no servers and the connection fails. Standard technologies (`openvpn_udp`, `openvpn_tcp`) work with any group or no group at all.
+
+See [Technologies](Technologies) for full details.

--- a/wiki/Supported-Platforms.md
+++ b/wiki/Supported-Platforms.md
@@ -1,0 +1,32 @@
+This image supports multiple CPU architectures. Docker will automatically pull the correct image for your platform.
+
+## Available Architectures
+
+| Architecture | Platform |
+|--------------|----------|
+| `386` | 32-bit x86 |
+| `amd64` | 64-bit x86 |
+| `arm/v6` | ARM v6 |
+| `arm/v7` | ARM v7 (Raspberry Pi 2/3) |
+| `arm64` | 64-bit ARM (Raspberry Pi 4/5, Apple M1) |
+| `riscv64` | 64-bit RISC-V |
+
+## Automatic Architecture Detection
+
+When you run `docker pull azinchen/nordvpn`, Docker automatically detects your system's architecture and pulls the appropriate image variant. No manual selection is required.
+
+## Verifying Your Architecture
+
+To check which architecture Docker is using:
+
+```bash
+docker image inspect azinchen/nordvpn:latest --format '{{.Architecture}}'
+```
+
+## Raspberry Pi Notes
+
+- **Raspberry Pi 2/3**: Uses `arm/v7`
+- **Raspberry Pi 4/5**: Uses `arm64` (recommended) or `arm/v7`
+- **Raspberry Pi Zero/1**: Uses `arm/v6`
+
+For best performance on Raspberry Pi 4 and newer, ensure you're running a 64-bit OS to take advantage of the `arm64` image.

--- a/wiki/Technologies.md
+++ b/wiki/Technologies.md
@@ -1,0 +1,109 @@
+This container uses OpenVPN exclusively. The `TECHNOLOGY` environment variable selects the protocol variant. Non-OpenVPN technologies (WireGuard, IKEv2, SOCKS, HTTP Proxy) are **not supported**.
+
+## Supported Technologies
+
+| Value | Protocol | Obfuscation | Default Port(s) | Requires `GROUP`? |
+|-------|----------|-------------|------------------|-------------------|
+| `openvpn_udp` | UDP | None | 1194 | No |
+| `openvpn_tcp` | TCP | None | 443 | No |
+| `openvpn_xor_udp` | UDP | XOR scramble | 53, 1194, 1198, 1214, 1215, 1216, 2231 | Yes |
+| `openvpn_xor_tcp` | TCP | XOR scramble | 20, 21, 80, 443, 465, 587, 993, 995 | Yes |
+| `openvpn_dedicated_udp` | UDP | None | 1194 | Yes |
+| `openvpn_dedicated_tcp` | TCP | None | 443 | Yes |
+
+The default is `openvpn_udp`.
+
+You can also use the human-readable names from the NordVPN API (e.g., `OpenVPN UDP`, `OpenVPN TCP`). The full list is in [TECHNOLOGIES.md](https://github.com/azinchen/nordvpn/blob/master/TECHNOLOGIES.md).
+
+## Standard OpenVPN (`openvpn_udp` / `openvpn_tcp`)
+
+The default mode. Connects to NordVPN's standard server fleet using a single port (UDP 1194 or TCP 443).
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_udp   # or openvpn_tcp
+```
+
+UDP is faster (less overhead); TCP is more reliable on restrictive networks that block UDP.
+
+## XOR Obfuscated OpenVPN (`openvpn_xor_udp` / `openvpn_xor_tcp`)
+
+XOR obfuscation disguises OpenVPN traffic using the [Tunnelblick XOR patch](https://github.com/Tunnelblick/Tunnelblick/tree/main/third_party/sources/openvpn), making it harder for deep packet inspection (DPI) to detect and block.
+
+### When to use
+
+- Your ISP or network blocks standard OpenVPN traffic
+- You're behind a corporate firewall that performs DPI
+- You're in a region where VPN protocols are actively filtered
+
+### Configuration
+
+XOR technologies **require** the `legacy_obfuscated_servers` group:
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_xor_tcp
+  - GROUP=legacy_obfuscated_servers
+```
+
+Without the `GROUP`, the NordVPN API returns no servers and connection will fail.
+
+All of this is transparent; just set `TECHNOLOGY` and `GROUP`.
+
+### XOR key override
+
+The default XOR scramble key is NordVPN's built-in key. If you need to override it (e.g., for a custom XOR server), set:
+
+```yaml
+environment:
+  - XOR_KEY=your_custom_key
+```
+
+### Multi-port behavior
+
+XOR connections use multiple ports with `remote-random`:
+
+| Protocol | Ports |
+|----------|-------|
+| XOR TCP | 20, 21, 80, 443, 465, 587, 993, 995 |
+| XOR UDP | 53, 1194, 1198, 1214, 1215, 1216, 2231 |
+
+The firewall automatically opens pinholes for all configured remote ports. Using common service ports (80, 443, 53) helps bypass port-based blocking.
+
+### Custom port selection
+
+By default, XOR configs include all available ports. To force a specific port, set the `PORT` environment variable:
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_xor_tcp
+  - GROUP=legacy_obfuscated_servers
+  - PORT=443
+```
+
+The port must be one the server actually listens on (see table above), otherwise the connection will fail. This also works with standard (non-XOR) technologies to override the default port.
+
+## Dedicated IP (`openvpn_dedicated_udp` / `openvpn_dedicated_tcp`)
+
+For NordVPN accounts with the [Dedicated IP add-on](https://nordvpn.com/features/dedicated-ip/). Requires the `legacy_dedicated_ip` group:
+
+```yaml
+environment:
+  - TECHNOLOGY=openvpn_dedicated_tcp
+  - GROUP=legacy_dedicated_ip
+```
+
+> **Note:** The API returns Dedicated IP servers regardless of your subscription status, but you need an active Dedicated IP add-on for your NordVPN account to successfully authenticate and use these servers.
+
+## Unsupported Technologies
+
+The NordVPN API lists several other OpenVPN technology identifiers that have **no servers assigned** and will not work:
+
+| Identifier | Status |
+|------------|--------|
+| `openvpn_udp_v6` | No servers |
+| `openvpn_tcp_v6` | No servers |
+| `openvpn_udp_tls_crypt` | No servers |
+| `openvpn_tcp_tls_crypt` | No servers |
+
+Non-OpenVPN technologies (`ikev2`, `wireguard_udp`, `socks`, `proxy`, etc.) are not compatible with this container.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,162 @@
+## Connection Problems
+
+### VPN won't connect
+
+**Symptoms:** Container starts but OpenVPN never establishes a tunnel.
+
+**Check:**
+1. **Credentials:** Verify you're using **service credentials**, not regular NordVPN login. See the [Getting Service Credentials](https://github.com/azinchen/nordvpn#getting-service-credentials) section in the README.
+2. **Logs:** `docker logs vpn` — look for auth errors or connection timeouts.
+3. **API access:** The container needs HTTPS access to NordVPN API IPs during bootstrap. If running behind a corporate proxy/firewall, ensure TCP/443 to the `NORDVPNAPI_IP` addresses is allowed.
+4. **TUN device:** Ensure `--device /dev/net/tun` is set and the device exists on the host.
+
+### Connection drops frequently
+
+**Fix:** Use health monitoring and aggressive reconnection:
+```yaml
+environment:
+  - CHECK_CONNECTION_CRON=*/5 * * * *
+  - CHECK_CONNECTION_URL=https://1.1.1.1
+  - OPENVPN_OPTS=--ping-exit 180
+  - RECREATE_VPN_CRON=0 */6 * * *
+```
+
+See [Automatic Reconnection](Automatic-Reconnection#connection-health-monitoring) for details.
+
+### VPN appears running but traffic is blocked
+
+**Symptoms:** tun0 exists but no traffic flows. Container started without errors.
+
+**Check:**
+1. **Connection timeout:** The container waits up to 60 seconds for tun0 to appear. If OpenVPN is slow to connect, it may proceed before the tunnel is fully established. Check logs for `Initialization Sequence Completed`.
+2. **Firewall rules:** `docker exec vpn iptables -L OUTPUT -n -v` — verify tun0 ACCEPT rule exists.
+3. **Diagnostics:** `docker exec vpn /usr/local/bin/network-diagnostic`
+
+## Networking Problems
+
+### Containers behind VPN have no network
+
+**Symptoms:** `docker exec app curl https://example.com` fails.
+
+**Check:**
+1. **VPN is up:** `docker exec vpn ip link show tun0` — if tun0 doesn't exist, the VPN isn't connected.
+2. **DNS:** `docker exec app cat /etc/resolv.conf` — the nameserver should be pushed by OpenVPN (usually `10.x.x.x`).
+3. **Firewall:** `docker exec vpn iptables -L -n` — verify OUTPUT chain allows traffic via tun0.
+
+### Can't access containers from LAN
+
+**Symptoms:** Can't reach published ports from your host or other LAN machines.
+
+**Fix:** Set `NETWORK` to include your LAN CIDR:
+```bash
+-e NETWORK=192.168.1.0/24
+```
+
+Docker subnets are **not** auto-allowed. If inter-container communication is needed, include Docker's subnet too.
+
+### DNS leaks
+
+**Symptoms:** DNS queries go through your ISP instead of the VPN tunnel.
+
+**Check:**
+1. Run diagnostics: `docker exec vpn /usr/local/bin/network-diagnostic`
+2. Look at the DNS section — nameservers should be VPN-provided addresses
+3. If using IPv6, it may bypass the VPN. See [IPv6 Configuration](IPv6-Configuration)
+
+### NETWORK setting defeats the kill switch
+
+**Symptoms:** Traffic leaks when VPN is down.
+
+**Cause:** `NETWORK` CIDRs are always allowed, regardless of VPN state. If you set `NETWORK=0.0.0.0/0`, **all traffic bypasses the VPN**.
+
+**Fix:** Keep `NETWORK` as narrow as possible — only include your LAN subnet and any Docker networks that need direct access.
+
+## Firewall & Permissions
+
+### iptables errors on container start
+
+**Symptoms:** Errors like `iptables: No chain/target/match by that name` or `Permission denied`.
+
+**Check:**
+1. **NET_ADMIN capability:** Ensure `--cap-add=NET_ADMIN` is set.
+2. **Kernel compatibility:** The container auto-detects nft vs legacy. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to see which was selected.
+3. **Host iptables modules:** Some minimal hosts (e.g., certain NAS devices) may lack required kernel modules.
+
+## Technologies
+
+### No servers found with XOR or Dedicated IP technology
+
+**Check:**
+- Verify `GROUP` is set correctly (`legacy_obfuscated_servers` for XOR, `legacy_dedicated_ip` for Dedicated IP)
+- Check that NordVPN has obfuscated/dedicated servers in your selected `COUNTRY`
+- Not all countries have obfuscated servers — try without `COUNTRY` first
+
+### Connection reset with XOR
+
+The TLS auth key swap happens automatically. If you see `Connection reset`, check the logs for TLS errors. Try the other protocol (`xor_tcp` ↔ `xor_udp`).
+
+### Connection timeout with XOR
+
+Standard OpenVPN uses a single port; XOR uses multiple. Ensure your network allows the required ports (see [Technologies](Technologies#multi-port-behavior)). If all XOR ports are blocked, standard OpenVPN TCP on port 443 may still work since it looks like HTTPS traffic.
+
+### Connection fails with PORT set
+
+Some servers don't accept all declared ports. If `PORT` is set and the connection fails, try a different port or remove `PORT` to let OpenVPN cycle through all available ports automatically.
+
+## Scheduling
+
+### Cron jobs not running
+
+**Symptoms:** `RECREATE_VPN_CRON` or `CHECK_CONNECTION_CRON` is set but the scheduled task never fires.
+
+**Check:**
+1. **Syntax:** Ensure valid cron format (5 fields: minute hour day month weekday). Invalid expressions are silently ignored by crond.
+2. **Logs:** Look for `[INIT-SETUPCRON]` lines at startup — they show the parsed schedule in human-readable format.
+3. **Crontab:** Verify the job was written: `docker exec vpn cat /var/spool/cron/crontabs/root`
+
+## Diagnostics
+
+### Built-in Network Diagnostics
+
+Enable automatic diagnostics on every VPN connection:
+
+```bash
+-e NETWORK_DIAGNOSTIC_ENABLED=true
+```
+
+Or run manually:
+
+```bash
+docker exec vpn /usr/local/bin/network-diagnostic          # full diagnostics
+docker exec vpn /usr/local/bin/network-diagnostic --basic   # IP + location only
+```
+
+The diagnostic tool checks: public IP and geolocation, OpenVPN connection status, network interfaces, firewall rules, DNS nameservers, IP routing table, and kernel version.
+
+### Reading Container Logs
+
+```bash
+docker logs vpn              # full logs
+docker logs -f vpn           # follow in real-time
+docker logs --tail 50 vpn    # last 50 lines
+```
+
+Key log messages:
+
+| Log message | Meaning |
+|------------|---------|
+| `[ENTRYPOINT] Using IPv4 backend: ...` | Firewall backend selected |
+| `[VPN-CONFIG] Server: ...` | Selected VPN server |
+| `Initialization Sequence Completed` | OpenVPN connected successfully |
+| `[HEALTHCHECK] Connection check failed` | Health check triggered reconnection |
+| `[VPN-RECONNECT] Reconnecting...` | Service restarting |
+
+### Inspecting the Container
+
+```bash
+docker exec vpn ip link show tun0            # check if VPN tunnel exists
+docker exec vpn ip route                     # view routing table
+docker exec vpn iptables -L -n -v            # check iptables rules
+docker exec vpn cat /run/xt/nordvpn.ovpn     # view OpenVPN config
+docker exec vpn env | sort                   # check environment
+```

--- a/wiki/Updating-and-Maintenance.md
+++ b/wiki/Updating-and-Maintenance.md
@@ -1,0 +1,26 @@
+When the `vpn` container is restarted — whether due to an image update or a manual restart — every container that uses `network_mode: "service:vpn"` must also be restarted so they reattach to the recreated network namespace.
+
+## With Docker Compose
+
+```bash
+docker compose pull
+docker compose up -d --force-recreate
+```
+
+## With Plain Docker (no Compose)
+
+```bash
+docker pull azinchen/nordvpn:latest   # or ghcr.io/azinchen/nordvpn:latest
+docker stop vpn && docker rm vpn
+# Re-run your "vpn" container with the same args as before...
+# Then restart each dependent container:
+docker restart webapp api-service redis
+```
+
+## Safer Automated Updates for Compose Stacks
+
+Consider using [azinchen/update-docker-containers](https://github.com/azinchen/update-docker-containers) for automated, safe container updates.
+
+## Why Dependent Containers Must Restart
+
+Containers that use `network_mode: "service:vpn"` share the VPN container's network namespace. When the VPN container is recreated, a new namespace is created. Dependent containers still reference the old (now dead) namespace and lose all network connectivity until they are restarted.

--- a/wiki/VPN-Gateway-Mode.md
+++ b/wiki/VPN-Gateway-Mode.md
@@ -1,0 +1,106 @@
+By default the container only routes **its own** traffic (and that of containers sharing its network namespace) through the VPN. **Gateway mode** lets the container act as a router for *other* containers that keep their own network namespace — for example a VPN server (ocserv, WireGuard, SoftEther…) whose clients should exit through NordVPN.
+
+This is the opposite of [`NETWORK`](Local-Network-Access): `NETWORK` lets traffic **bypass** the tunnel to reach your LAN, while `FORWARD_FROM` lets downstream traffic **route out through** the tunnel.
+
+## What `FORWARD_FROM` Does
+
+When `FORWARD_FROM` is set, the `init-firewall` script, for each CIDR:
+
+1. Adds `FORWARD -s <cidr> -o tun0 -j ACCEPT` — lets that subnet's traffic leave through the tunnel.
+2. Adds the matching `tun0 → <cidr>` `ESTABLISHED,RELATED` return rule.
+
+The existing `POSTROUTING -o tun0 -j MASQUERADE` rule then NATs the forwarded packets onto the tunnel, so no extra NAT is needed.
+
+Only the **`FORWARD`** chain is opened — `INPUT`/`OUTPUT` stay locked by the kill switch, and the rules reference `tun0`. If the tunnel drops, they cannot match, so **downstream traffic is dropped rather than leaked**.
+
+## Requirements
+
+- **Enable IPv4 forwarding** on the container: `--sysctl net.ipv4.ip_forward=1`.
+- **Downstream traffic must arrive already SNATed** into one of the `FORWARD_FROM` CIDRs (i.e. masqueraded to the downstream container's address on the shared docker network). That way the gateway needs **no return route** to the downstream client subnet — replies come back to an address it already knows.
+
+## Multiple Subnets
+
+`FORWARD_FROM` is semicolon- or comma-separated, just like `NETWORK`:
+
+```bash
+-e FORWARD_FROM="172.28.0.0/24;10.30.0.0/24;192.168.50.0/24"
+```
+
+## Docker Compose Example: ocserv (OpenConnect) server
+
+This routes an [ocserv](https://github.com/azinchen/ocserv-server) OpenConnect/AnyConnect server's clients out through NordVPN. The `azinchen/ocserv-server` image takes a **`VPN_GATEWAY`** variable, so it SNATs its own VPN clients into the shared docker network and policy-routes them to the gateway for you — no manual `ip route`/`ip rule` needed on the downstream container.
+
+```yaml
+networks:
+  vpnnet:
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24
+
+services:
+  vpn:
+    image: azinchen/nordvpn:latest
+    container_name: ocserv-nordvpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    sysctls:
+      - net.ipv4.ip_forward=1                # required: forward downstream traffic
+    environment:
+      - USER=service_username
+      - PASS=service_password
+      - COUNTRY=Netherlands
+      - FORWARD_FROM=172.28.0.0/24           # the docker net ocserv SNATs into
+    networks:
+      vpnnet:
+        ipv4_address: 172.28.0.2             # static, so ocserv can route to it
+    restart: unless-stopped
+
+  ocserv:
+    image: azinchen/ocserv-server:latest
+    container_name: ocserv-server
+    depends_on:
+      - vpn
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun                         # ocserv is a userspace VPN server, so it DOES need TUN
+    sysctls:
+      - net.ipv4.ip_forward=1                # required on the downstream too
+    ports:
+      - "8443:443/tcp"                       # published normally on ocserv itself
+    environment:
+      - VPN_SUBNET=10.20.0.0/24              # address pool handed to OpenConnect clients
+      - VPN_GATEWAY=172.28.0.2               # route those clients out via the nordvpn gateway
+      - IPV6_FORWARD=0                       # upstream is IPv4-only: disable IPv6 to avoid leaks
+      - IPV6_NAT=0
+    networks:
+      vpnnet:
+        ipv4_address: 172.28.0.3
+    restart: unless-stopped
+```
+
+Flow: an OpenConnect client gets an address from `10.20.0.0/24` → `ocserv` masquerades it to its own `172.28.0.3` (inside the `FORWARD_FROM` net) and policy-routes it to `172.28.0.2` → `nordvpn` forwards it out the tunnel and masquerades it onto `tun0`. Replies return the same way. The client's public IP is then the NordVPN exit, and if the tunnel drops the kill switch blocks the forwarded traffic too.
+
+> **Both containers need `net.ipv4.ip_forward=1`** (set above via `sysctls`).
+
+## Downstream containers without a built-in gateway option
+
+`azinchen/ocserv-server` handles routing via `VPN_GATEWAY`. For a generic downstream container that has no such option, route **only the client subnet** out through the gateway with a policy rule, keeping the container's default route on the docker bridge.
+
+Do **not** simply point the downstream's **default route** at the gateway — it breaks the downstream's own published ports: an inbound connection is `DNAT`ed in, but its reply would follow the default route into the tunnel and exit with the wrong source IP, so the client drops it.
+
+```sh
+# on the downstream container; 172.28.0.2 = this nordvpn gateway
+ip route replace default via 172.28.0.2 table 100
+ip rule add from 10.20.0.0/24 lookup 100 priority 1000
+```
+
+The routing decision happens before the downstream container's own SNAT, so the `from 10.20.0.0/24` match works; client traffic goes to the gateway, while the listener's replies and the container's own traffic stay on the bridge.
+
+## Security Notes
+
+- **Keep `FORWARD_FROM` as narrow as possible** — every listed CIDR may route out through the tunnel.
+- Forwarding is gated on `tun0`, so the kill switch still applies: no tunnel, no forwarding.
+- This does **not** open any inbound ports on the gateway; publish the downstream service's ports on the downstream container.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,7 @@
+---
+
+**[NordVPN OpenVPN Docker Container](https://github.com/azinchen/nordvpn)** · [README](https://github.com/azinchen/nordvpn#readme) · [Releases](https://github.com/azinchen/nordvpn/releases) · [Issues](https://github.com/azinchen/nordvpn/issues) · [Docker Hub](https://hub.docker.com/r/azinchen/nordvpn)
+
+Prefer WireGuard? See the sibling project **[azinchen/nordvpn-wg](https://github.com/azinchen/nordvpn-wg)** ([wiki](https://github.com/azinchen/nordvpn-wg/wiki)).
+
+Maintained by [Alexander Zinchenko](mailto:alexander@zinchenko.com) · Licensed under [AGPL-3.0](https://github.com/azinchen/nordvpn/blob/master/LICENSE)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,31 @@
+**[Home](Home)**
+
+**Configuration**
+- [Server Selection](Server-Selection)
+- [Server Groups](Server-Groups)
+- [Technologies](Technologies)
+- [IPv6 Configuration](IPv6-Configuration)
+- [Automatic Reconnection](Automatic-Reconnection)
+- [Local Network Access](Local-Network-Access)
+- [VPN Gateway Mode](VPN-Gateway-Mode)
+- [OpenVPN Options](OpenVPN-Options)
+- [Custom DNS](Custom-DNS)
+- [Permissions](Permissions)
+
+**Security**
+- [Security Model](Security-Model)
+- [Firewall Backends](Firewall-Backends)
+
+**Examples**
+- [Docker Compose Examples](Docker-Compose-Examples)
+- [Docker Run Examples](Docker-Run-Examples)
+
+**Operations**
+- [Updating and Maintenance](Updating-and-Maintenance)
+- [Troubleshooting](Troubleshooting)
+- [Network Diagnostics Guide](Network-Diagnostics-Guide)
+
+**Reference**
+- [FAQ](FAQ)
+- [Supported Platforms](Supported-Platforms)
+- [Architecture and Internals](Architecture-and-Internals)


### PR DESCRIPTION
## Summary

- Remove the `wiki` git submodule (`.gitmodules` deleted) and track all 23 wiki pages directly in `wiki/`, so wiki changes can go through normal PRs in this repo.
- Add `.github/workflows/wiki-publish.yml` (**Docs - Publish Wiki**), which mirrors `wiki/` into the GitHub wiki repository and pushes directly to its `master` branch.

## Workflow behavior

- **Triggers:** every tag (release) push, plus `workflow_dispatch` from any branch or tag.
- **Sync:** `rsync --delete` makes the wiki repo exactly mirror `wiki/` (adds, replaces, and deletes pages).
- **Versioned history:** commits are titled `Publish wiki for <version>`; when content is unchanged an empty marker commit is still pushed so every release is recorded in the wiki history. The version is the tag or branch name the workflow runs on.
- **Auth:** uses the built-in `GITHUB_TOKEN` (`contents: write`) to push to `<repo>.wiki.git` — no extra secrets needed.

## Notes

- Wiki content is unchanged; it is the current submodule state (`acf365e`).