### PR TITLE
Centralize uplink and tunnel interface names

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -10,13 +10,8 @@ SCRIPT_NAME="INIT-FIREWALL"
 log "$SCRIPT_NAME" "Starting firewall initialization"
 log "$SCRIPT_NAME" "Configuring firewall to route all traffic through VPN"
 
-
 # BusyBox-friendly helpers
-
-docker_network="$(ip addr show dev eth0 2>/dev/null | awk '/inet / {print $2; exit}')"
-
-# BusyBox-friendly helpers
-docker_network="$(ip addr show dev eth0 2>/dev/null | awk '/inet / {print $2; exit}')"
+docker_network="$(ip addr show dev "$wan_if" 2>/dev/null | awk '/inet / {print $2; exit}')"
 gw="$(ip route 2>/dev/null | awk '/default/ {print $3; exit}')"
 
 # ===================== IPv4 =====================
@@ -28,15 +23,15 @@ if [ -n "$docker_network" ]; then
     run4_critical -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
     # Allow outbound to VPN interfaces + NAT
-    run4_critical -A OUTPUT -o tun0 -j ACCEPT
-    run4_critical -t nat -A POSTROUTING -o tun0 -j MASQUERADE
+    run4_critical -A OUTPUT -o "$tun_if" -j ACCEPT
+    run4_critical -t nat -A POSTROUTING -o "$tun_if" -j MASQUERADE
 
     # Create named chain for VPN Server rules
     # Do not restrict by port here — svc-nordvpn adds per-IP:port rules
     # into VPN-SERVER at runtime (XOR uses non-standard ports)
     run4 -N VPN-SERVER
-    run4 -A OUTPUT -o eth0 -p udp -j VPN-SERVER
-    run4 -A OUTPUT -o eth0 -p tcp -j VPN-SERVER
+    run4 -A OUTPUT -o "$wan_if" -p udp -j VPN-SERVER
+    run4 -A OUTPUT -o "$wan_if" -p tcp -j VPN-SERVER
 
     # NordVPN API bootstrap (TCP/443) by resolved IPs
     if [ -n "$nordvpnapi_ip" ]; then
@@ -57,12 +52,12 @@ if [ -n "$docker_network" ]; then
             [ -z "$net" ] && continue
             # Best-effort route add (if not already present)
             if [ -n "$gw" ]; then
-                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev eth0 2>/dev/null || true
+                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null || true
             fi
             # Allow inbound from this network only
-            run4 -A INPUT -i eth0 -s "$net" -j ACCEPT
+            run4 -A INPUT -i "$wan_if" -s "$net" -j ACCEPT
             # Allow outbound to this network only
-            run4 -A OUTPUT -o eth0 -d "$net" -j ACCEPT
+            run4 -A OUTPUT -o "$wan_if" -d "$net" -j ACCEPT
         done
         IFS="$oldIFS"
     fi
@@ -77,14 +72,14 @@ if [ -n "$docker_network" ]; then
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
             [ -z "$net" ] && continue
-            run4_critical -A FORWARD -s "$net" -o tun0 -j ACCEPT
-            run4_critical -A FORWARD -d "$net" -i tun0 \
+            run4_critical -A FORWARD -s "$net" -o "$tun_if" -j ACCEPT
+            run4_critical -A FORWARD -d "$net" -i "$tun_if" \
                 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
         done
         IFS="$oldIFS"
     fi
 else
-    log "$SCRIPT_NAME" "No IPv4 address on eth0, skipping IPv4 rules"
+    log "$SCRIPT_NAME" "No IPv4 address on ${wan_if}, skipping IPv4 rules"
 fi
 
 log "$SCRIPT_NAME" "Firewall initialization completed"

--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -50,9 +50,9 @@ awk '/^[[:space:]]*remote[ \t]+/ {print $2, $3}' "$ovpnfile" | while read -r r_i
         continue
     fi
 
-    PIN_SPEC="-A VPN-SERVER -o eth0 -p ${r_proto} -d ${r_ip} --dport ${r_port} -j ACCEPT"
+    PIN_SPEC="-A VPN-SERVER -o ${wan_if} -p ${r_proto} -d ${r_ip} --dport ${r_port} -j ACCEPT"
     if run4 $PIN_SPEC 2>/dev/null; then
-        log "$SCRIPT_NAME" "Added firewall pinhole for ${r_proto} traffic to ${r_ip}:${r_port} on interface eth0"
+        log "$SCRIPT_NAME" "Added firewall pinhole for ${r_proto} traffic to ${r_ip}:${r_port} on interface ${wan_if}"
     fi
 done
 

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -32,6 +32,10 @@ forward_from="${FORWARD_FROM:-}"
 puid=${PUID:-912}
 pgid=${PGID:-912}
 
+# Interfaces
+wan_if="eth0"
+tun_if="tun0"
+
 # Common file paths
 ovpntemplatefile="/usr/local/share/nordvpn/data/template.ovpn"
 ovpnfile="/run/xt/nordvpn.ovpn"
@@ -76,7 +80,7 @@ run6_critical() {
 
 # Check if VPN is connected by checking for tun interface
 is_vpn_connected() {
-    if ip link show tun0 >/dev/null 2>&1; then
+    if ip link show "$tun_if" >/dev/null 2>&1; then
         return 0
     else
         return 1

--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -322,7 +322,7 @@ PUBLIC_TEST_IPv6="2606:4700:4700::1111"
 
 # Initialize variables with defaults
 COMMON_NAME=""
-DEV_IF="tun0"
+DEV_IF="$tun_if"
 DEV_TYPE="?"
 IFCONF_LOCAL="?"
 IFCONF_REMOTE="?"


### PR DESCRIPTION
## Summary

Replaces the `eth0`/`tun0` literals scattered across the scripts with `wan_if`/`tun_if` variables defined once in `backend-functions`, mirroring the sibling `azinchen/openconnect-client` image (part of syncing conventions across the three gateway images).

No functional change — the values are still `eth0`/`tun0`.

## Changes

- `backend-functions`: new `wan_if`/`tun_if` definitions; `is_vpn_connected` uses `tun_if`
- `init-firewall/run`: literals replaced with the variables; removed a duplicated `docker_network` computation
- `svc-nordvpn/run`: per-remote `VPN-SERVER` pinhole uses `wan_if`
- `network-diagnostic`: `DEV_IF` derives from `tun_if`

## Testing

- `sh -n` on all modified scripts
- `git grep` confirms no functional `eth0`/`tun0` literals remain outside comments