### PR TITLE
docs: tuning guidance for connection check and rotation

### DIFF
--- a/wiki/Automatic-Reconnection.md
+++ b/wiki/Automatic-Reconnection.md
@@ -15,7 +15,23 @@ Use `RECREATE_VPN_CRON` to periodically switch to a different server. This uses 
 -e RECREATE_VPN_CRON="0 */4 * * *"
 ```
 
-When triggered, the cron job stops the `svc-nordvpn` service, which causes it to restart automatically. On restart, `vpn-config` re-fetches the server list and selects a new server based on current load.
+When triggered, `vpn-reconnect` selects a new server and prepares the new config **while the current tunnel stays up** — the API calls and load sorting no longer count as downtime. Only then is the service restarted to apply it, so the actual interruption is the OpenVPN restart and TLS handshake (a few seconds). If server selection fails (for example the API is unreachable), the existing connection is kept untouched.
+
+### Making rotation effective
+
+Server selection always takes the top of the filtered pool (NordVPN's recommended order for a single location, load-sorted for multiple locations). Without further settings a scheduled rotation can therefore re-select the very server you are already on. Set `RANDOM_TOP` so rotation actually lands somewhere new:
+
+```bash
+-e RANDOM_TOP=10
+```
+
+This shuffles the ten best servers in the pool and picks one — a genuinely different exit IP on almost every rotation, while still staying on low-load recommended servers. Larger values add IP variety but start including higher-load servers; see [Server Selection](Server-Selection) for how the pool is built.
+
+### Choosing a schedule
+
+- **Server hygiene** (avoid sitting on a server that slowly degrades): daily off-peak, e.g. `0 6 * * *`, is plenty. A good default for seedboxes and gateways, since every rotation changes the exit IP and drops long-lived connections (torrent peers re-announce, sessions reset). Note the container runs on UTC unless `TZ` is set.
+- **IP rotation for privacy**: every few hours, e.g. `0 */6 * * *` or `0 */4 * * *`. Going below hourly gains little and constantly disturbs anything stateful.
+- **Latency-sensitive, single pinned city**: scheduled rotation can be skipped entirely — recommended-order selection already favors the best server at connect time, and failure handling plus health monitoring (below) move you off a broken one.
 
 ## Connection Failure Handling
 
@@ -43,10 +59,10 @@ Using `--ping-exit` causes OpenVPN to **exit** on timeout, which triggers svc-no
 Use the `CHECK_CONNECTION_*` variables for active health probing:
 
 ```bash
--e CHECK_CONNECTION_CRON="*/5 * * * *"
--e CHECK_CONNECTION_URL="https://1.1.1.1;https://8.8.8.8"
+-e CHECK_CONNECTION_CRON="* * * * *"
+-e CHECK_CONNECTION_URL="https://www.gstatic.com/generate_204;https://cp.cloudflare.com/generate_204"
 -e CHECK_CONNECTION_ATTEMPTS=3
--e CHECK_CONNECTION_ATTEMPT_INTERVAL=10
+-e CHECK_CONNECTION_ATTEMPT_INTERVAL=5
 ```
 
 | Variable | Default | Description |
@@ -55,6 +71,17 @@ Use the `CHECK_CONNECTION_*` variables for active health probing:
 | `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (semicolon-separated) |
 | `CHECK_CONNECTION_ATTEMPTS` | `5` | Number of retry attempts |
 | `CHECK_CONNECTION_ATTEMPT_INTERVAL` | `10` | Seconds between retries |
+
+A check passes as soon as **any** URL answers with HTTP 2xx/3xx, so listing two URLs on independent infrastructure prevents a single provider's outage (or a geo-block on some exit servers) from triggering a spurious reconnect. The dedicated connectivity endpoints `https://www.gstatic.com/generate_204` and `https://cp.cloudflare.com/generate_204` are ideal: no body, no redirects, and they answer from everywhere.
+
+### Tuning the schedule
+
+Two timings matter:
+
+- **Run length.** A fully failing check runs for about `ATTEMPTS × (2s timeout + ATTEMPT_INTERVAL)` seconds (the interval elapses after the last attempt too). Keep this below the cron period so runs don't overlap — the defaults (5 × ~12s ≈ 60s) are too long for an every-minute cron; pair a `* * * * *` schedule with `ATTEMPTS=3` and `ATTEMPT_INTERVAL=5` (~20s).
+- **Worst-case recovery.** Time from outage to reconnect is roughly `cron period + run length` — about 1.5 minutes with an every-minute cron and 3×5s retries.
+
+Don't shrink the retries too far: the retry window should outlast a transient blip (a brief ISP hiccup, a server-side pause) and the few seconds of downtime a scheduled rotation or an OpenVPN `--ping-restart` causes. A reconnect changes the exit IP, which resets anything sensitive to it — one failed request should never rotate the server; 15+ seconds of nothing getting through should.
 
 ## Docker Health Status
 
@@ -74,13 +101,20 @@ When enabled, the probe checks that the `tun0` interface exists and that a singl
 
 ## Recommended Setup
 
-For most users, combining scheduled reconnection with health monitoring provides robust connectivity:
+For most users, combining scheduled rotation, OpenVPN's own failure detection and health monitoring provides robust connectivity:
 
 ```yaml
 environment:
-  - RECREATE_VPN_CRON=0 */6 * * *           # Switch server every 6 hours
-  - CHECK_CONNECTION_CRON=*/5 * * * *       # Check every 5 minutes
-  - CHECK_CONNECTION_URL=https://1.1.1.1    # Fast, reliable endpoint
+  - RECREATE_VPN_CRON=0 6 * * *             # Rotate daily, off-peak (UTC unless TZ is set)
+  - RANDOM_TOP=10                           # So rotation lands on a different server
+  - CHECK_CONNECTION_CRON=* * * * *         # Probe every minute
   - CHECK_CONNECTION_ATTEMPTS=3
+  - CHECK_CONNECTION_ATTEMPT_INTERVAL=5
+  - CHECK_CONNECTION_URL=https://www.gstatic.com/generate_204;https://cp.cloudflare.com/generate_204
+  - HEALTHCHECK_ENABLED=true
   - OPENVPN_OPTS=--ping-exit 180            # Exit if server unresponsive for 3 min
 ```
+
+This detects a dead tunnel and finishes reconnecting within ~1.5 minutes worst case (the `--ping-exit` layer catches server-side silence independently), tolerates short blips without rotating the exit IP, and rotates to a fresh low-load server once a day.
+
+For long-lived connections where an IP change is disruptive (seedbox, remote sessions), lean more conservative: `CHECK_CONNECTION_CRON=*/2 * * * *`, `CHECK_CONNECTION_ATTEMPTS=4`, `CHECK_CONNECTION_ATTEMPT_INTERVAL=10` — about 45 seconds of confirmed failure before the server is rotated. If the check cron runs infrequently, pick a rotation minute that doesn't collide with it (e.g. check on `*/5`, rotate at minute 2); with an every-minute check the overlap is harmless — a check landing during the restart is absorbed by the retries.


### PR DESCRIPTION
Ports the reconnection-tuning wiki update from azinchen/nordvpn-wg#223 to the **Automatic Reconnection** page, adapted to this image's OpenVPN mechanics (verified against the current `vpn-reconnect`/`vpn-healthcheck` scripts).

### Corrections
- Scheduled reconnection is no longer a plain `svc-nordvpn` restart: `vpn-reconnect` prepares the new config while the current tunnel stays up, then restarts the service — downtime is only the OpenVPN restart and TLS handshake, and a failed selection keeps the current connection.

### New guidance
- **Health check tuning**: run length is `ATTEMPTS × (2s timeout + ATTEMPT_INTERVAL)` and must stay below the cron period (defaults overlap an every-minute cron); worst-case recovery ≈ cron period + run length. Recommend `* * * * *` with `3×5s` retries and `generate_204` endpoints on two independent providers.
- **Rotation**: scheduled rotation can re-select the current server unless `RANDOM_TOP` is set; schedule recommendations per use case (daily hygiene / periodic privacy rotation / skip when latency-sensitive).
- **Recommended setup** refreshed with a tuned baseline (keeping the `--ping-exit` passive detection layer) plus a conservative variant for long-lived connections.