### PR TITLE
fix: trim whitespace around delimited list values

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-firewall/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-firewall/run
@@ -38,6 +38,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing NordVPN API access for IPs: ${nordvpnapi_ip}"
         oldIFS="$IFS"; IFS=',;'
         for ip in $nordvpnapi_ip; do
+            ip="$(trim "$ip")"
             [ -z "$ip" ] && continue
             run4 -A OUTPUT -d "$ip" -p tcp --dport 443 -j ACCEPT
         done
@@ -49,10 +50,14 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing access to custom networks: ${network}"
         oldIFS="$IFS"; IFS=',;'
         for net in $network; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
-            # Best-effort route add (if not already present)
+            # Best-effort route add (if not already present); warn instead of
+            # failing so one bad value doesn't block the rest, but stays visible
             if [ -n "$gw" ]; then
-                ip route 2>/dev/null | grep -q " ${net} " || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null || true
+                ip route 2>/dev/null | grep -q " ${net} " \
+                    || ip route add "$net" via "$gw" dev "$wan_if" 2>/dev/null \
+                    || log_warning "$SCRIPT_NAME" "Warning: failed to add route for NETWORK value \"$net\""
             fi
             # Allow inbound from this network only
             run4 -A INPUT -i "$wan_if" -s "$net" -j ACCEPT
@@ -71,6 +76,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Allowing tunnel forwarding from: ${forward_from}"
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
             run4_critical -A FORWARD -s "$net" -o "$tun_if" -j ACCEPT
             run4_critical -A FORWARD -d "$net" -i "$tun_if" \
@@ -103,7 +109,7 @@ if [ -n "$docker_network" ]; then
     elif [ "$gateway_dns" != "off" ]; then
         dns_target=""
         if [ "$gateway_dns" = "forward" ]; then
-            dns_target="$(echo "$gateway_dns_server" | tr ',;' '\n' | grep -v ':' | head -1)"
+            dns_target="$(trim "$(echo "$gateway_dns_server" | tr ',;' '\n' | grep -v ':' | awk 'NF {print; exit}')")"
             if [ -z "$dns_target" ]; then
                 log_error "$SCRIPT_NAME" "CRITICAL ERROR: GATEWAY_DNS=forward requires an IPv4 GATEWAY_DNS_SERVER - sleeping infinite"
                 sleep infinity
@@ -115,6 +121,7 @@ if [ -n "$docker_network" ]; then
         log "$SCRIPT_NAME" "Intercepting client DNS: mode=${gateway_dns}${dns_target:+ target=$dns_target}"
         oldIFS="$IFS"; IFS=',;'
         for net in $forward_from; do
+            net="$(trim "$net")"
             [ -z "$net" ] && continue
             for proto in udp tcp; do
                 case "$gateway_dns" in

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -51,6 +51,16 @@ mgmtpwfile="/run/xt/mgmt-pw"
 mgmt_host="127.0.0.1"
 mgmt_port="7505"
 
+# Strip leading/trailing whitespace from a list token. Values like
+# "10.0.0.0/16; 10.1.0.0/16" split on IFS=',;' keep the space, which then
+# breaks ip/iptables/curl silently. Pure-shell so it works under BusyBox.
+trim() {
+    _t="$1"
+    _t="${_t#"${_t%%[![:space:]]*}"}"
+    _t="${_t%"${_t##*[![:space:]]}"}"
+    printf '%s' "$_t"
+}
+
 run4() {
     if ! ${IPT} "$@" 2>/dev/null; then
         log "BACKEND" "(IPv4) skipped: $*"

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -363,6 +363,7 @@ nord_api_curl()
     # If failed, fallback to using predefined API IPs
     oldIFS="$IFS"; IFS=',;'
     for _ip in $nordvpnapi_ip; do
+        _ip="$(trim "$_ip")"
         [ -n "$_ip" ] || continue
 
         curl -sG --connect-timeout 10 --max-time 30 \
@@ -418,6 +419,7 @@ if [ -n "$country" ]; then
     # Convert semicolon/comma separated list to space separated
     oldIFS="$IFS"; IFS=',;';
     for value in $country; do
+        value="$(trim "$value")"
         if [ -n "$value" ]; then
             locations_count=$((locations_count + 1))
         fi
@@ -462,6 +464,7 @@ if [ -n "$city" ]; then
     # Convert semicolon/comma separated list to space separated
     oldIFS="$IFS"; IFS=',;'
     for value in $city; do
+        value="$(trim "$value")"
         if [ -n "$value" ]; then
             locations_count=$((locations_count + 1))
         fi

--- a/root/usr/local/bin/vpn-healthcheck
+++ b/root/usr/local/bin/vpn-healthcheck
@@ -23,6 +23,8 @@ while [ $counter -le "$check_connection_attempts" ]; do
     # Convert semicolon separated list to space separated
     oldIFS="$IFS"; IFS=',;'
     for url in $check_connection_url; do
+        url="$(trim "$url")"
+        [ -n "$url" ] || continue
         if httpreq "$url"; then
             log "$SCRIPT_NAME" "VPN connection is active"
             exit 0

--- a/root/usr/local/bin/vpn-healthcheck-probe
+++ b/root/usr/local/bin/vpn-healthcheck-probe
@@ -25,6 +25,7 @@ is_vpn_connected || exit 1
 #    request (no retry loop; Docker --retries absorbs transient blips).
 oldIFS="$IFS"; IFS=',;'
 for url in $check_connection_url; do
+    url="$(trim "$url")"
     [ -n "$url" ] || continue
     code="$(curl -s --max-time 5 -o /dev/null -w '%{http_code}' -I "$url" 2>/dev/null || printf '000')"
     case "$code" in


### PR DESCRIPTION
## Summary

Fixes #1234 — whitespace after `;`/`,` delimiters in list-valued environment variables was kept as part of each token, causing silent failures (e.g. `NETWORK: "10.10.0.0/16; 10.20.0.0/16"` only installed the first route).

## Changes

- Add a POSIX/BusyBox-safe `trim()` helper to `backend-functions` (pure parameter expansion, no `xargs`/`sed`)
- Apply it at all nine `IFS=',;'` split sites, before the empty-token guard so whitespace-only tokens are skipped too:
  - `init-firewall/run`: NordVPN API IPs, `NETWORK`, `FORWARD_FROM` (forwarding + GATEWAY_DNS loops)
  - `vpn-config`: API-IP curl fallback, `COUNTRY`, `CITY` (trim happens before the `locations_count` increment, so padded-empty entries no longer inflate the count)
  - `vpn-healthcheck` / `vpn-healthcheck-probe`: `CHECK_CONNECTION_URL` (the cron healthcheck also gains the previously missing empty-token guard)
- Make the original failure mode visible: a failed `NETWORK` route add now logs a warning instead of being discarded with `|| true`
- `GATEWAY_DNS=forward` target selection skips blank entries (`awk 'NF'` instead of `head -1`) and trims the result, so a padded `GATEWAY_DNS_SERVER` list resolves to a usable IPv4 address

Trimming was chosen over widening `IFS` with whitespace because `COUNTRY`/`CITY` values legitimately contain spaces (`COUNTRY=United States;CA`).

## Testing

- `trim()` and the split loops verified under BusyBox `ash`, `dash` and `bash`: `"10.10.0.0/16; 10.20.0.0/16 ;192.168.0.0/24;;  ; 10.30.0.0/16"` yields exactly the four clean CIDRs; `"  United States  "` trims without inner-space damage
- shellcheck: warning counts identical before/after on all five files