### PR TITLE
docs(wiki): document list separators and whitespace tolerance

### DIFF
--- a/wiki/Automatic-Reconnection.md
+++ b/wiki/Automatic-Reconnection.md
@@ -68,7 +68,7 @@ Use the `CHECK_CONNECTION_*` variables for active health probing:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CHECK_CONNECTION_CRON` | Disabled | Cron schedule for health checks |
-| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (semicolon-separated) |
+| `CHECK_CONNECTION_URL` | `https://www.google.com` | URLs to probe (`;`/`,`-separated) |
 | `CHECK_CONNECTION_ATTEMPTS` | `5` | Number of retry attempts |
 | `CHECK_CONNECTION_ATTEMPT_INTERVAL` | `10` | Seconds between retries |
 

--- a/wiki/Local-Network-Access.md
+++ b/wiki/Local-Network-Access.md
@@ -15,7 +15,7 @@ docker run -d --cap-add=NET_ADMIN --device /dev/net/tun \
            azinchen/nordvpn
 ```
 
-Multiple CIDRs are semicolon-separated:
+Multiple CIDRs are separated by `;` or `,` (whitespace around separators is ignored):
 
 ```bash
 -e NETWORK="192.168.1.0/24;172.20.0.0/16;10.0.0.0/8"

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -10,7 +10,7 @@ This page describes the container's firewall behavior, kill switch, and network 
 
 ## Network Access Control (Exceptions)
 
-- **Local/LAN access (bidirectional, explicit):** Set `NETWORK=192.168.1.0/24` (semicolon-separated CIDRs supported) to allow access to those subnets **regardless of VPN status**.
+- **Local/LAN access (bidirectional, explicit):** Set `NETWORK=192.168.1.0/24` (`;`/`,`-separated CIDRs supported) to allow access to those subnets **regardless of VPN status**.
 - **No domain names allowed:** Use IPs in `NETWORK` for any non-VPN access you require.
 
 ## Rule Precedence

--- a/wiki/Server-Selection.md
+++ b/wiki/Server-Selection.md
@@ -21,7 +21,7 @@ docker run -d --cap-add=NET_ADMIN --device /dev/net/tun \
 | **CITY** | Name or numeric ID | `New York`, `8971718` |
 | **Specific server** | Hostname (in COUNTRY or CITY) | `es1234`, `uk2567` |
 
-Multiple values are semicolon-separated: `COUNTRY="United States;CA;228"`
+Multiple values are separated by `;` or `,` (whitespace around separators is ignored): `COUNTRY="United States;CA;228"`
 
 ### Specific Server Hostname Format
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -54,6 +54,14 @@ See [Automatic Reconnection](Automatic-Reconnection#connection-health-monitoring
 
 Docker subnets are **not** auto-allowed. If inter-container communication is needed, include Docker's subnet too.
 
+### Only some NETWORK subnets are reachable
+
+**Symptoms:** With multiple CIDRs in `NETWORK` (or `FORWARD_FROM`), only the first one works; `docker exec vpn ip route` is missing routes for the others.
+
+**Cause:** Older releases did not trim whitespace in list values, so `NETWORK="10.10.0.0/16; 10.20.0.0/16"` (note the space after `;`) silently skipped every value after the first separator. Current images ignore whitespace around separators and log a warning when a route cannot be added.
+
+**Fix:** Update to the latest image, or remove the spaces after `;`/`,`.
+
 ### DNS leaks
 
 **Symptoms:** DNS queries go through your ISP instead of the VPN tunnel.

--- a/wiki/VPN-Gateway-Mode.md
+++ b/wiki/VPN-Gateway-Mode.md
@@ -20,7 +20,7 @@ Only the **`FORWARD`** chain is opened — `INPUT`/`OUTPUT` stay locked by the k
 
 ## Multiple Subnets
 
-`FORWARD_FROM` is semicolon- or comma-separated, just like `NETWORK`:
+`FORWARD_FROM` takes CIDRs separated by `;` or `,` (whitespace around separators is ignored), just like `NETWORK`:
 
 ```bash
 -e FORWARD_FROM="172.28.0.0/24;10.30.0.0/24;192.168.50.0/24"


### PR DESCRIPTION
## Summary

Follow-up to #1235/#1236, wiki only:

- Unified separator wording on five pages — list values accept `;` or `,`, and whitespace around separators is ignored:
  - `Server-Selection.md` (`COUNTRY`/`CITY` values)
  - `Local-Network-Access.md` (`NETWORK` CIDRs)
  - `VPN-Gateway-Mode.md` (`FORWARD_FROM` CIDRs)
  - `Security-Model.md` (`NETWORK` mention)
  - `Automatic-Reconnection.md` (`CHECK_CONNECTION_URL` table row)

  Previously four of these said semicolon-only while `VPN-Gateway-Mode` already mentioned commas.

- Added a Troubleshooting entry for the #1234 symptom (*Only some NETWORK subnets are reachable*): images predating the trimming silently skip every CIDR after a `"; "` separator. Phrased without version numbers so the wiki matches current `master` behavior — fix is "update to the latest image, or remove the spaces".

Rest of the wiki was reviewed against current master: documented defaults, README cross-links (including the `#getting-service-credentials` anchor), and the internals described in Architecture-and-Internals are all still accurate — no other changes needed.