### PR TITLE
feat: fetch OpenVPN service credentials via NordVPN API with TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Also available from GitHub Container Registry: `ghcr.io/azinchen/nordvpn`
 ### Requirements
 
 - Docker with `--cap-add=NET_ADMIN` and `--device /dev/net/tun`
-- **NordVPN Service Credentials** (not regular account credentials)
+- **NordVPN service credentials** or an **access token** (not regular account credentials)
 
 ### Getting Service Credentials
 
@@ -63,6 +63,8 @@ Also available from GitHub Container Registry: `ghcr.io/azinchen/nordvpn`
 4. Copy the **Username** and **Password** shown there
 
 > **Note**: These are different from your regular NordVPN login credentials.
+
+**Alternative — access token:** instead of copying the service credentials, generate an access token (**Nord Account Dashboard** → **NordVPN** → **Advanced Settings** → **Generate new token**) and pass it as `TOKEN`; the container then fetches the service credentials from the NordVPN API at startup. If `USER`/`PASS` are also set, they take priority over the token.
 
 ## Docker Compose Example
 
@@ -101,12 +103,13 @@ services:
 
 ### Credentials
 
-NordVPN **service credentials** — see [Getting Service Credentials](#getting-service-credentials) above.
+NordVPN **service credentials**, set directly or fetched automatically with an access token — see [Getting Service Credentials](#getting-service-credentials) above.
 
 | Variable | Details |
 |---|---|
-| **USER** | **Required** — NordVPN service credentials username. |
-| **PASS** | **Required** — NordVPN service credentials password. |
+| **USER** | NordVPN service credentials username. **Required** unless `TOKEN` is set. |
+| **PASS** | NordVPN service credentials password. **Required** unless `TOKEN` is set. |
+| **TOKEN** | NordVPN access token; the service credentials are fetched from the NordVPN API at startup. Ignored when `USER`/`PASS` are set. |
 
 ### Server Selection
 

--- a/root/etc/s6-overlay/s6-rc.d/init-createauth/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/init-createauth/dependencies
@@ -1,1 +1,2 @@
 init-adduser
+init-firewall

--- a/root/etc/s6-overlay/s6-rc.d/init-createauth/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-createauth/run
@@ -9,9 +9,32 @@ SCRIPT_NAME="INIT-CREATEAUTH"
 
 log "$SCRIPT_NAME" "Starting authentication setup"
 
+# Resolve credentials: explicit USER/PASS take priority; otherwise fetch the
+# service credentials from the NordVPN API using TOKEN.
+if [ -n "${USER:-}" ] && [ -n "${PASS:-}" ]; then
+    if [ -n "$token" ]; then
+        log "$SCRIPT_NAME" "Both USER/PASS and TOKEN are set - using USER/PASS"
+    fi
+    auth_user="$USER"
+    auth_pass="$PASS"
+elif [ -n "$token" ]; then
+    log "$SCRIPT_NAME" "Fetching service credentials from NordVPN API using TOKEN"
+    creds="$(nord_api_curl "v1/users/services/credentials" -u "token:${token}")" || creds=""
+    auth_user="$(printf '%s' "$creds" | jq -r '.username // empty' 2>/dev/null || true)"
+    auth_pass="$(printf '%s' "$creds" | jq -r '.password // empty' 2>/dev/null || true)"
+    if [ -z "$auth_user" ] || [ -z "$auth_pass" ]; then
+        log_error "$SCRIPT_NAME" "CRITICAL ERROR: Could not fetch service credentials with TOKEN (check that the token is valid and not expired) - sleeping infinite"
+        sleep infinity
+    fi
+    log "$SCRIPT_NAME" "Service credentials fetched from NordVPN API"
+else
+    log_error "$SCRIPT_NAME" "CRITICAL ERROR: No credentials provided - set USER/PASS or TOKEN - sleeping infinite"
+    sleep infinity
+fi
+
 log "$SCRIPT_NAME" "Creating VPN authentication file"
-echo "$user" > "$authfile"
-echo "$pass" >> "$authfile"
+printf '%s\n' "$auth_user" > "$authfile"
+printf '%s\n' "$auth_pass" >> "$authfile"
 chmod 0600 "$authfile"
 chown nordvpn:nordvpn "$authfile"
 

--- a/root/etc/s6-overlay/s6-rc.d/init-createmgmtpwfile/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/init-createmgmtpwfile/dependencies
@@ -1,0 +1,1 @@
+init-createauth

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -23,7 +23,7 @@ check_connection_attempt_interval="${CHECK_CONNECTION_ATTEMPT_INTERVAL:-10}"
 healthcheck_enabled="$(to_bool "${HEALTHCHECK_ENABLED:-}")"
 user="${USER:-}"
 pass="${PASS:-}"
-mgmt_pw="$pass"
+token="${TOKEN:-}"
 recreate_vpn_cron="${RECREATE_VPN_CRON:-}"
 check_connection_cron="${CHECK_CONNECTION_CRON:-}"
 nordvpnapi_ip="${NORDVPNAPI_IP:-104.16.208.203;104.19.159.190}"
@@ -51,6 +51,16 @@ mgmtpwfile="/run/xt/mgmt-pw"
 mgmt_host="127.0.0.1"
 mgmt_port="7505"
 
+# TOKEN mode: init-createauth fetches the service credentials from the NordVPN
+# API and stores them in $authfile; scripts running later pick them up here so
+# $user/$pass (and the management password) stay valid without USER/PASS being
+# set. USER/PASS take priority over the fetched values when both are present.
+if { [ -z "$user" ] || [ -z "$pass" ]; } && [ -s "$authfile" ]; then
+    user="$(sed -n '1p' "$authfile" 2>/dev/null || true)"
+    pass="$(sed -n '2p' "$authfile" 2>/dev/null || true)"
+fi
+mgmt_pw="$pass"
+
 # Strip leading/trailing whitespace from a list token. Values like
 # "10.0.0.0/16; 10.1.0.0/16" split on IFS=',;' keep the space, which then
 # breaks ip/iptables/curl silently. Pure-shell so it works under BusyBox.
@@ -59,6 +69,41 @@ trim() {
     _t="${_t#"${_t%%[![:space:]]*}"}"
     _t="${_t%"${_t##*[![:space:]]}"}"
     printf '%s' "$_t"
+}
+
+# Query the NordVPN API: try DNS resolution first, then fall back to the
+# predefined bootstrap IPs (DNS may be unavailable under the default-deny
+# firewall). Extra arguments are passed to curl.
+nord_api_curl()
+{
+    _path="$1"
+    shift 2>/dev/null || true
+
+    # First, try without predefined API IPs (use DNS resolution)
+    curl -sG --connect-timeout 10 --max-time 30 \
+        "https://api.nordvpn.com/${_path}" "$@"
+    _rc=$?
+    if [ $_rc -eq 0 ]; then
+        return 0
+    fi
+
+    # If failed, fallback to using predefined API IPs
+    oldIFS="$IFS"; IFS=',;'
+    for _ip in $nordvpnapi_ip; do
+        _ip="$(trim "$_ip")"
+        [ -n "$_ip" ] || continue
+
+        curl -sG --connect-timeout 10 --max-time 30 \
+             --resolve "api.nordvpn.com:443:${_ip}" \
+             "https://api.nordvpn.com/${_path}" "$@"
+        _rc=$?
+        if [ $_rc -eq 0 ]; then
+            IFS="$oldIFS"
+            return 0
+        fi
+    done
+    IFS="$oldIFS"
+    return $_rc
 }
 
 run4() {

--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -347,38 +347,6 @@ handle_specific_server()
     return 1
 }
 
-nord_api_curl()
-{
-    _path="$1"
-    shift 2>/dev/null || true
-
-    # First, try without predefined API IPs (use DNS resolution)
-    curl -sG --connect-timeout 10 --max-time 30 \
-        "https://api.nordvpn.com/${_path}" "$@"
-    _rc=$?
-    if [ $_rc -eq 0 ]; then
-        return 0
-    fi
-
-    # If failed, fallback to using predefined API IPs
-    oldIFS="$IFS"; IFS=',;'
-    for _ip in $nordvpnapi_ip; do
-        _ip="$(trim "$_ip")"
-        [ -n "$_ip" ] || continue
-
-        curl -sG --connect-timeout 10 --max-time 30 \
-             --resolve "api.nordvpn.com:443:${_ip}" \
-             "https://api.nordvpn.com/${_path}" "$@"
-        _rc=$?
-        if [ $_rc -eq 0 ]; then
-            IFS="$oldIFS"
-            return 0
-        fi
-    done
-    IFS="$oldIFS"
-    return $_rc
-}
-
 servers=""
 locations_count=0
 

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -8,9 +8,12 @@ The container uses [s6-overlay](https://github.com/just-containers/s6-overlay) f
 entrypoint (container start)
   │
   ├─ init-adduser        Create nordvpn user/group
-  ├─ init-createauth     Write credentials file (0600, owned by nordvpn)
-  ├─ init-createmgmtpwfile  Generate management interface password
   ├─ init-firewall       Apply iptables rules (depends on entrypoint backend selection)
+  ├─ init-createauth     Write credentials file (0600, owned by nordvpn); with TOKEN,
+  │                      fetches service credentials from the NordVPN API first
+  │                      (runs after init-firewall so the API pinholes exist)
+  ├─ init-createmgmtpwfile  Generate management interface password (after init-createauth,
+  │                      so TOKEN-fetched credentials are available)
   ├─ init-setupcron      Configure cron jobs from RECREATE_VPN_CRON / CHECK_CONNECTION_CRON
   │
   ├─ svc-nordvpn         Main OpenVPN service (long-running)
@@ -46,6 +49,7 @@ Sourced by every script. Provides:
 - `run4()` / `run6()` — Execute iptables commands with logging (non-fatal)
 - `run4_critical()` / `run6_critical()` — Execute or sleep forever on failure
 - `is_vpn_connected()` — Checks for tun0 interface
+- `nord_api_curl()` — Queries the NordVPN API, falling back to bootstrap IPs when DNS is unavailable
 - `mgmt_cmd()` — Sends authenticated commands to OpenVPN management interface
 - `log()` / `log_error()` / `log_warning()` — Timestamped logging
 - `parse_cron()` — Converts cron expressions to human-readable descriptions

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -6,6 +6,9 @@ No. You need **service credentials** (a separate username/password) specifically
 **Q: Where do I find my service credentials?**
 Log into [Nord Account Dashboard](https://my.nordaccount.com/) → NordVPN → Advanced Settings → Set up NordVPN manually → Service credentials tab.
 
+**Q: Can I use an access token instead of service credentials?**
+Yes. Generate a token (Nord Account Dashboard → NordVPN → Advanced Settings → Generate new token) and set it as `TOKEN` — the container fetches the service credentials from the NordVPN API at startup. If `USER`/`PASS` are also set, they take priority over the token.
+
 ## Features
 
 **Q: Does this support WireGuard?**

--- a/wiki/Security-Model.md
+++ b/wiki/Security-Model.md
@@ -30,7 +30,7 @@ Because `NETWORK` remains open when the VPN is down, this is **not a strict kill
 
 ### Credential Exposure
 
-Credentials passed via `USER` and `PASS` environment variables are:
+Credentials passed via the `USER`, `PASS`, and `TOKEN` environment variables are:
 - Visible via `docker inspect` on the container
 - Visible in the process environment
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -5,7 +5,7 @@
 **Symptoms:** Container starts but OpenVPN never establishes a tunnel.
 
 **Check:**
-1. **Credentials:** Verify you're using **service credentials**, not regular NordVPN login. See the [Getting Service Credentials](https://github.com/azinchen/nordvpn#getting-service-credentials) section in the README.
+1. **Credentials:** Verify you're using **service credentials** (or a valid access token via `TOKEN`), not regular NordVPN login. See the [Getting Service Credentials](https://github.com/azinchen/nordvpn#getting-service-credentials) section in the README.
 2. **Logs:** `docker logs vpn` — look for auth errors or connection timeouts.
 3. **API access:** The container needs HTTPS access to NordVPN API IPs during bootstrap. If running behind a corporate proxy/firewall, ensure TCP/443 to the `NORDVPNAPI_IP` addresses is allowed.
 4. **TUN device:** Ensure `--device /dev/net/tun` is set and the device exists on the host.


### PR DESCRIPTION
## Summary

Adds a `TOKEN` environment variable as an alternative to `USER`/`PASS`. With a NordVPN access token set, `init-createauth` fetches the OpenVPN service credentials from the NordVPN API (`GET v1/users/services/credentials`, basic auth `token:<TOKEN>`) at startup and writes them to the auth file.

**Priority:** explicit `USER`/`PASS` (both set) always win; `TOKEN` is only used otherwise. Neither set → clear critical error (`sleep infinity`, the repo's standard for fatal config errors) instead of the previous silent empty auth file.

## Implementation notes

- `nord_api_curl` moved from `vpn-config` to `backend-functions` (unchanged) so `init-createauth` reuses the DNS-first / bootstrap-IP-fallback API access — the fetch works under the default-deny firewall exactly like server selection does.
- **s6 ordering:** `init-createauth` now depends on `init-firewall` (entrypoint sets default-DROP before services start, so the API 443 pinholes must exist before the fetch), and `init-createmgmtpwfile` depends on `init-createauth`.
- **Management interface in TOKEN mode:** `backend-functions` resolves `user`/`pass` from the auth file when `USER`/`PASS` are absent, so `mgmt_pw` (and every later consumer — reconnect, healthcheck) keeps working with fetched credentials.
- Auth file written with `printf` instead of `echo` (robust for values starting with `-`).

## Docs

- **README:** requirements line, Credentials table (+`TOKEN` row, USER/PASS now "Required unless TOKEN is set"), and an access-token paragraph in *Getting Service Credentials*.
- **Wiki:** FAQ (new token Q&A), Troubleshooting (credentials check mentions TOKEN), Security-Model (TOKEN listed in credential-exposure note), Architecture-and-Internals (boot sequence reflects the new dependencies, `nord_api_curl` listed as a shared helper).

## Testing

- shellcheck: no new findings on any touched script (counts before/after compared); BusyBox `sh -n` syntax-checked.
- Credential-resolution logic simulated under BusyBox ash: token-only (fetched creds + mgmt password), USER/PASS priority, no-credentials error path, and API response parsing for both success and `Unauthorized` shapes.