### PR TITLE
feat: use API bootstrap IPs exclusively, drop DNS resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Low‑level settings; the defaults work for most setups.
 
 | Variable | Details |
 |---|---|
-| **NORDVPNAPI<wbr>_IP** | API bootstrap IPs. Default: `104.16.208.203;104.19.159.190` |
+| **NORDVPNAPI<wbr>_IP** | IPs used for all NordVPN API access (no DNS involved). Default: `104.16.208.203;104.19.159.190` |
 | **NETWORK<wbr>_DIAGNOSTIC<wbr>_ENABLED** | Enable network diagnostics on connect ([details][wiki-diagnostics]). Default: `false` |
 
 ## Issues

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -69,39 +69,32 @@ trim() {
     printf '%s' "$_t"
 }
 
-# Query the NordVPN API: try DNS resolution first, then fall back to the
-# predefined bootstrap IPs (DNS may be unavailable under the default-deny
-# firewall). Extra arguments are passed to curl.
+# Query the NordVPN API via the predefined bootstrap IPs - the only endpoints
+# allowed through the default-deny firewall before the tunnel is up, so DNS is
+# deliberately not used. The default IPs are kept current by the maintenance
+# workflow; NORDVPNAPI_IP overrides them. Extra arguments are passed to curl.
 nord_api_curl()
 {
     _path="$1"
     shift 2>/dev/null || true
 
-    # First, try without predefined API IPs (use DNS resolution)
-    curl -sG --connect-timeout 10 --max-time 30 \
-        "https://api.nordvpn.com/${_path}" "$@"
-    _rc=$?
-    if [ $_rc -eq 0 ]; then
-        return 0
-    fi
-
-    # If failed, fallback to using predefined API IPs
+    _rc=1
     oldIFS="$IFS"; IFS=',;'
     for _ip in $nordvpnapi_ip; do
         _ip="$(trim "$_ip")"
         [ -n "$_ip" ] || continue
 
-        curl -sG --connect-timeout 10 --max-time 30 \
-             --resolve "api.nordvpn.com:443:${_ip}" \
-             "https://api.nordvpn.com/${_path}" "$@"
-        _rc=$?
-        if [ $_rc -eq 0 ]; then
+        if curl -sG --connect-timeout 10 --max-time 30 \
+                --resolve "api.nordvpn.com:443:${_ip}" \
+                "https://api.nordvpn.com/${_path}" "$@"; then
             IFS="$oldIFS"
             return 0
+        else
+            _rc=$?
         fi
     done
     IFS="$oldIFS"
-    return $_rc
+    return "$_rc"
 }
 
 run4() {

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -48,7 +48,7 @@ Sourced by every script. Provides:
 - `run4()` / `run6()` — Execute iptables commands with logging (non-fatal)
 - `run4_critical()` / `run6_critical()` — Execute or sleep forever on failure
 - `is_vpn_connected()` — Checks for tun0 interface
-- `nord_api_curl()` — Queries the NordVPN API, falling back to bootstrap IPs when DNS is unavailable
+- `nord_api_curl()` — Queries the NordVPN API via the bootstrap IPs (`NORDVPNAPI_IP`); no DNS dependency
 - `mgmt_cmd()` — Sends authenticated commands to OpenVPN management interface
 - `log()` / `log_error()` / `log_warning()` — Timestamped logging
 - `parse_cron()` — Converts cron expressions to human-readable descriptions


### PR DESCRIPTION
## Summary

`nord_api_curl` now uses the bootstrap IPs (`NORDVPNAPI_IP`) **exclusively** — the DNS-name path is removed entirely (this PR originally just reordered the attempts; scope updated after review).

Rationale:
- Before the tunnel is up, the default-deny firewall only pinholes the bootstrap IPs on 443 — DNS is blocked and a freshly resolved IP wouldn't be allowed through anyway, so the DNS attempt failed on every pre-connect call (live-verified: `000` on each).
- Stale-IP protection doesn't need a runtime fallback: the `update-nordvpn-api-ips` job in `maintenance-updates.yml` refreshes the baked-in default and a new image is released when the API addresses change; `NORDVPNAPI_IP` remains overridable at runtime.

Implementation: iterate over the IPs with `--resolve`, return on first success, propagate curl's exit code when all fail; loop body written as `if curl ...; then` so the function is `set -e`-safe in any calling context.

Docs: README `NORDVPNAPI_IP` row ("IPs used for all NordVPN API access (no DNS involved)") and the Architecture wiki helper description updated.

## Testing

Rebuilt image, live-tested:
- `TOKEN` mode: credential fetch + VPN connect work (API reached via first bootstrap IP, `200`)
- Dead IP list (`192.0.2.1`): fails with curl's real exit code (28) and no DNS rescue, as intended
- shellcheck: no new findings