### PR TITLE
fix: do not crash-loop on non-OpenVPN TECHNOLOGY values

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -534,7 +534,10 @@ fi
 serverip=$(echo "$servers" | jq -r '.station' | head -n 1)
 name=$(echo "$servers" | jq -r '.name' | head -n 1)
 hostname=$(echo "$servers" | jq -r '.hostname' | head -n 1)
-protocol=$(getopenvpnprotocol "$technology")
+# `|| true` so a non-OpenVPN technology (e.g. TECHNOLOGY=Wireguard) doesn't
+# kill the script under `set -e`; the empty protocol falls through to the
+# CRITICAL ERROR + fail() branch below, which logs the actual problem.
+protocol=$(getopenvpnprotocol "$technology" || true)
 
 # Extract location information
 country_name=$(echo "$servers" | jq -r '.locations[0].country.name' | head -n 1)


### PR DESCRIPTION
## Summary

Bug: `protocol=$(getopenvpnprotocol "$technology")` (vpn-config:537) is a bare top-level assignment under `set -eu`. `getopenvpnprotocol` legitimately returns 1 for identifiers that don't contain "openvpn" — including valid entries from `technologies.json` (`Wireguard`, `ikev2`, `nordwhisper`) and any typo. The script died on that line with zero log output, so `svc-nordvpn` crash-looped with nothing explaining why, bypassing the `CRITICAL ERROR: TECHNOLOGY ... wrong parameter` + `fail()` branch written for exactly this case (vpn-config:603-606).

Fix: `|| true` on the assignment (the pattern already used at the other lookup call sites in this file), so the empty protocol falls through the udp/tcp chain into the existing error branch, which logs the actual problem and blocks the supervisor instead of crash-looping.

## Testing

- Reproduced pre-fix failure shape and post-fix survival under BusyBox ash `set -eu`
- shellcheck/syntax clean