### PR TITLE
fix: continue server selection when a specific server lookup fails

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -394,7 +394,10 @@ if [ -n "$country" ]; then
         if is_specific_server "$value"; then
             log "$SCRIPT_NAME" "Specific server requested: $value"
             log_warning "$SCRIPT_NAME" "Warning: Ensure server $value supports TECHNOLOGY=$technology and GROUP=$group, otherwise connection will fail"
-            servers="$servers$(handle_specific_server "$value")"
+            # `|| true` so an unknown/retired hostname doesn't kill the script
+            # under `set -e`; handle_specific_server already logs the failure
+            # and the loop continues with the remaining values.
+            servers="$servers$(handle_specific_server "$value" || true)"
         elif [ -n "$value" ]; then
             # `|| true` so an unknown country (e.g. user passing a US state code)
             # doesn't silently kill the script under `set -e`; the -z branch
@@ -439,7 +442,10 @@ if [ -n "$city" ]; then
         if is_specific_server "$value"; then
             log "$SCRIPT_NAME" "Specific server requested: $value"
             log_warning "$SCRIPT_NAME" "Warning: Ensure server $value supports TECHNOLOGY=$technology and GROUP=$group, otherwise connection will fail"
-            servers="$servers$(handle_specific_server "$value")"
+            # `|| true` so an unknown/retired hostname doesn't kill the script
+            # under `set -e`; handle_specific_server already logs the failure
+            # and the loop continues with the remaining values.
+            servers="$servers$(handle_specific_server "$value" || true)"
         elif [ -n "$value" ]; then
             # See COUNTRY loop above for the rationale behind `|| true`.
             cityid=$(getcityid "$value" || true)


### PR DESCRIPTION
## Summary

Bug: `servers="$servers$(handle_specific_server "$value")"` (vpn-config:397 and 442) is an assignment under `set -eu` — when a user-requested hostname (e.g. `COUNTRY=us1234`) no longer exists or is mistyped, `handle_specific_server` returns 1 and the whole script dies mid-loop: the remaining `COUNTRY`/`CITY` values are never processed and the `fail()` block-forever contract is bypassed (crash-loop instead of a clear error).

Fix: `|| true` at both call sites, matching the guarded lookup pattern used everywhere else in the file. `handle_specific_server` already logs the failed lookup; the loop now continues with the remaining values, and if nothing at all resolves the existing "list of selected servers is empty" CRITICAL branch reports it.

## Testing

- Loop-continuation semantics reproduced under BusyBox ash `set -eu` (bad value logged, good values still collected)
- shellcheck/syntax clean