### PR TITLE
fix: extract the peer address instead of 'AF_INET' in diagnostics

### DIFF
--- a/root/usr/local/bin/network-diagnostic
+++ b/root/usr/local/bin/network-diagnostic
@@ -99,7 +99,7 @@ get_openvpn_status()
         MGMT_SOURCE="management interface"
         # For client connections, try to extract from different lines
         # Look for remote server info in the status output
-        COMMON_NAME="$(printf "%s" "$MGMT_RESP" | grep -o 'TCP connection established with \[AF_INET\][0-9.]*:[0-9]*' | sed 's/.*\[\([^]]*\)\].*/\1/' | cut -d: -f1 || printf '')"
+        COMMON_NAME="$(printf "%s" "$MGMT_RESP" | grep -o 'TCP connection established with \[AF_INET\][0-9.]*:[0-9]*' | sed 's/.*\[AF_INET\]//' | cut -d: -f1 || printf '')"
         
         # Extract remote IP from status (TCP or UDP)
         TCP_LINE="$(printf "%s" "$MGMT_RESP" | grep 'TCP connection established' | head -1 || printf '')"


### PR DESCRIPTION
## Summary

Bug: in `network-diagnostic`, the Common Name extraction used `sed 's/.*\[\([^]]*\)\].*/\1/'` — the capture group matches the `[AF_INET]` bracket pair itself, so whenever this branch runs the diagnostic prints the literal string `AF_INET` instead of the peer address. Diagnostic-only, not service-affecting.

Fix: strip everything up to and including `[AF_INET]` (`sed 's/.*\[AF_INET\]//'`), leaving `IP:port` for the existing `cut -d: -f1`.

Verified: `TCP connection established with [AF_INET]185.230.126.1:443` → `185.230.126.1` (was `AF_INET`).