### PR TITLE
fix: start crond only after svc-nordvpn is launched

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-cron/dependencies
+++ b/root/etc/s6-overlay/s6-rc.d/svc-cron/dependencies
@@ -1,1 +1,2 @@
 init-setupcron
+svc-nordvpn


### PR DESCRIPTION
## Summary

Bug: `svc-cron` and `svc-nordvpn` are independent members of the `user` bundle with no ordering, so `crond` could begin firing scheduled jobs (`vpn-reconnect`, `vpn-healthcheck`) before the VPN service was even started — and `vpn-reconnect` unconditionally does `s6-rc stop svc-nordvpn; s6-rc start svc-nordvpn`, which could interleave with the very first connection attempt under a tight cron schedule.

Fix: add `svc-nordvpn` to `svc-cron`'s dependencies so crond starts only after the VPN service has been launched.

Caveat stated in the commit: `svc-nordvpn` has no s6 readiness notification, so this orders *startup*, not *tunnel-up* — but it closes the pre-start window, and the first cron tick after start is then bounded by the schedule granularity rather than racing service creation itself.

## Testing

- Dependency graph change only; verified no cycles (`svc-cron` → `svc-nordvpn` → init-* → nothing back to svc-cron)
- Will be covered by the container boot in the follow-up lifecycle PRs' image tests