### PR TITLE
fix: keep TOKEN out of the process command line

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-createauth/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-createauth/run
@@ -19,7 +19,12 @@ if [ -n "${USER:-}" ] && [ -n "${PASS:-}" ]; then
     auth_pass="$PASS"
 elif [ -n "$token" ]; then
     log "$SCRIPT_NAME" "Fetching service credentials from NordVPN API using TOKEN"
-    creds="$(nord_api_curl "v1/users/services/credentials" -u "token:${token}")" || creds=""
+    # Pass the token via a 0600 curl config file, not -u on the command line,
+    # so it never appears in /proc/*/cmdline or ps output
+    curlcfg="$(mktemp /run/xt/curl-auth.XXXXXX)"
+    printf 'user = "token:%s"\n' "$token" > "$curlcfg"
+    creds="$(nord_api_curl "v1/users/services/credentials" -K "$curlcfg")" || creds=""
+    rm -f "$curlcfg"
     auth_user="$(printf '%s' "$creds" | jq -r '.username // empty' 2>/dev/null || true)"
     auth_pass="$(printf '%s' "$creds" | jq -r '.password // empty' 2>/dev/null || true)"
     if [ -z "$auth_user" ] || [ -z "$auth_pass" ]; then


### PR DESCRIPTION
## Summary

Security fix: `init-createauth` invoked `curl ... -u token:<TOKEN>` — since curl is a real binary, the literal token was visible in `/proc/<pid>/cmdline`/`ps` to any process in the container's PID namespace (including co-located apps in `network_mode: service:vpn` setups if PID sharing is enabled) for the duration of the API call.

Fix: write the credentials to a `mktemp` curl config file (created 0600) as a `user = "token:..."` line and pass `-K <file>`; the file is deleted immediately after the fetch. The config file also survives `nord_api_curl`'s multi-IP retry loop, unlike a stdin-based approach which would be consumed by the first attempt.

## Testing

- `mktemp` verified to create the file 0600
- Live-verified against the real API: `-K` config auth returns `200` with a valid token; the no-auth control returns `401`
- BusyBox syntax check clean