### PR TITLE
fix: report firewall pinhole failures instead of claiming success

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -51,8 +51,10 @@ awk '/^[[:space:]]*remote[ \t]+/ {print $2, $3}' "$ovpnfile" | while read -r r_i
     fi
 
     PIN_SPEC="-A VPN-SERVER -o ${wan_if} -p ${r_proto} -d ${r_ip} --dport ${r_port} -j ACCEPT"
-    if run4 $PIN_SPEC 2>/dev/null; then
+    if run4_check $PIN_SPEC; then
         log "$SCRIPT_NAME" "Added firewall pinhole for ${r_proto} traffic to ${r_ip}:${r_port} on interface ${wan_if}"
+    else
+        log_warning "$SCRIPT_NAME" "Warning: failed to add firewall pinhole for ${r_ip}:${r_port} - connection to this server may be blocked"
     fi
 done
 

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -97,9 +97,20 @@ nord_api_curl()
     return "$_rc"
 }
 
+# Best-effort by design: always returns 0 so plain call sites under `set -e`
+# never abort the caller. Use run4_check when the caller needs the real status.
 run4() {
     if ! ${IPT} "$@" 2>/dev/null; then
         log "BACKEND" "(IPv4) skipped: $*"
+    fi
+}
+
+# Like run4 but propagates the iptables exit status, for callers that branch
+# on whether the rule was actually added.
+run4_check() {
+    if ! ${IPT} "$@" 2>/dev/null; then
+        log "BACKEND" "(IPv4) skipped: $*"
+        return 1
     fi
 }
 


### PR DESCRIPTION
## Summary

Bug: `run4()` unconditionally returns 0 — when the wrapped iptables command fails, the function's last command is the (succeeding) `log`, so the pinhole loop in `svc-nordvpn/run` printed **"Added firewall pinhole for ..."** immediately after run4's own **"(IPv4) skipped: ..."** line. Operators debugging "why can't I reach the VPN server" got false assurance the rule existed.

Fix:
- New `run4_check()` in `backend-functions`: same logging, but propagates the real iptables exit status.
- The pinhole call site uses it and now logs an explicit warning ("connection to this server may be blocked") on failure.
- `run4`/`run6` deliberately stay always-0 (now documented as best-effort): their plain call sites in `init-firewall` run under `set -e`, where a propagated failure would abort firewall initialization.

## Testing

- Both branches verified under BusyBox ash with `set -eu` (failure detected, success detected, caller survives)
- shellcheck/syntax clean