### PR TITLE
fix: serialize concurrent vpn-reconnect runs with a lock

### DIFF
--- a/root/usr/local/bin/vpn-reconnect
+++ b/root/usr/local/bin/vpn-reconnect
@@ -7,6 +7,28 @@ set -eu
 
 SCRIPT_NAME="VPN-RECONNECT"
 
+# Serialize reconnections: RECREATE_VPN_CRON, CHECK_CONNECTION_CRON (via
+# vpn-healthcheck) and manual invocations are independent and can overlap;
+# two concurrent runs would race on the shared build/staged config paths and
+# interleave s6-rc stop/start calls. mkdir is atomic, so it doubles as a lock;
+# a lock whose owner is gone (crashed mid-run) is taken over.
+lockdir="/run/xt/vpn-reconnect.lock"
+if ! mkdir "$lockdir" 2>/dev/null; then
+    holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && [ -d "/proc/$holder" ]; then
+        log "$SCRIPT_NAME" "Another reconnection (pid $holder) is already in progress - skipping"
+        exit 0
+    fi
+    log_warning "$SCRIPT_NAME" "Removing stale reconnection lock (owner gone)"
+    rm -rf "$lockdir"
+    if ! mkdir "$lockdir" 2>/dev/null; then
+        log "$SCRIPT_NAME" "Another reconnection grabbed the lock first - skipping"
+        exit 0
+    fi
+fi
+echo "$$" > "$lockdir/pid"
+trap 'rm -rf "$lockdir"' EXIT INT TERM
+
 log "$SCRIPT_NAME" "Starting VPN reconnection"
 
 # Select a new server and build the new config while the CURRENT tunnel stays


### PR DESCRIPTION
## Summary

Bug: nothing serialized reconnections. `RECREATE_VPN_CRON` and `CHECK_CONNECTION_CRON`→`vpn-healthcheck`→`vpn-reconnect` are independent cron entries (plus manual runs), and two concurrent `vpn-config` invocations race on the fixed paths `/run/xt/nordvpn.ovpn.tmp` / `.staged` — the `cp` template reset from one run can land mid-way through the other's `sed -i` edits, producing configs with unresolved `__PROTOCOL__`/`__REMOTES__` placeholders, and the two runs then interleave `s6-rc stop/start svc-nordvpn` calls.

Fix: an atomic `mkdir` lock (`/run/xt/vpn-reconnect.lock`) at the top of `vpn-reconnect`:
- second invocation logs "already in progress" and exits 0 (the in-flight reconnect achieves the same goal)
- the owner pid is recorded; a lock whose owner died mid-run (checked via `/proc/<pid>`) is taken over rather than deadlocking
- `trap ... EXIT INT TERM` releases the lock on every exit path, including the `--fail-fast` failure branch

## Testing

- Concurrency simulated under BusyBox ash: second concurrent run skips while first holds; stale lock (dead pid) is taken over; lock removed on exit in all cases
- shellcheck/syntax clean