### PR TITLE
fix: hard-kill fallback for OpenVPN shutdown via pidfile

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/finish
@@ -29,18 +29,46 @@ fi
 # is signalled, so we poll its resources instead of waiting on the PID. Polling
 # (vs a fixed sleep) returns the moment it's gone, cutting reconnect downtime;
 # the loop still caps the wait so a stuck shutdown can't hang finish.
+# True only when the recorded pid is alive AND still an openvpn process (pid
+# reuse safety); sets _pid for the kill fallback below.
+openvpn_alive() {
+    _pid="$(cat /run/xt/openvpn.pid 2>/dev/null || true)"
+    [ -n "$_pid" ] || return 1
+    case "$(tr '\0' '\n' 2>/dev/null < "/proc/$_pid/cmdline" | head -n 1)" in
+        *openvpn*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 wait_counter=0
 while is_mgmt_available || is_vpn_connected; do
     wait_counter=$((wait_counter + 1))
     if [ "$wait_counter" -ge 50 ]; then
-        log "$SCRIPT_NAME" "OpenVPN still shutting down after timeout, continuing"
+        # Graceful shutdown didn't finish in 5s. A lingering OpenVPN would
+        # collide with the next start on the management port and tun0, so
+        # escalate: SIGTERM by pid, then SIGKILL.
+        if openvpn_alive; then
+            log_warning "$SCRIPT_NAME" "OpenVPN (pid $_pid) still running after graceful timeout - sending SIGTERM"
+            kill -TERM "$_pid" 2>/dev/null || true
+            kill_counter=0
+            while [ -d "/proc/$_pid" ] && [ "$kill_counter" -lt 20 ]; do
+                kill_counter=$((kill_counter + 1))
+                sleep 0.1
+            done
+            if [ -d "/proc/$_pid" ]; then
+                log_warning "$SCRIPT_NAME" "OpenVPN did not exit on SIGTERM - sending SIGKILL"
+                kill -KILL "$_pid" 2>/dev/null || true
+            fi
+        else
+            log "$SCRIPT_NAME" "OpenVPN still shutting down after timeout, continuing"
+        fi
         break
     fi
     sleep 0.1
 done
 
 log "$SCRIPT_NAME" "Cleaning up VPN configuration files"
-rm -f "$ovpnfile"
+rm -f "$ovpnfile" /run/xt/openvpn.pid
 
 log "$SCRIPT_NAME" "NordVPN service stopped"
 exit 0

--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -70,6 +70,10 @@ chmod 0600 "$openvpn_extra"
 log "$SCRIPT_NAME" "Launching OpenVPN"
 openvpn --group nordvpn --config "$ovpnfile" --config "$openvpn_extra" --auth-user-pass "$authfile" --auth-nocache --management "$mgmt_host" "$mgmt_port" "$mgmtpwfile" &
 
+# Record the PID so finish can hard-kill a hung OpenVPN; the process is
+# orphaned when this shell is signalled, so the pidfile is the only handle.
+echo $! > /run/xt/openvpn.pid
+
 # Wait for VPN connection
 log "$SCRIPT_NAME" "Waiting for VPN connection..."
 counter=0


### PR DESCRIPTION
## Summary

Bug: `svc-nordvpn/run` backgrounds `openvpn` with `&` and never records the PID, so `finish`'s shutdown depended entirely on the management interface. If the mgmt `signal SIGTERM` failed (mgmt not yet listening, auth issue) or OpenVPN took longer than the 5s resource poll, `finish` logged "still shutting down, continuing" and returned 0 — s6 then started a **new** openvpn that collided with the orphaned old one on `127.0.0.1:7505` and `tun0`, leaving the container tunnel-less until manual intervention.

Fix:
- `run` writes `$!` to `/run/xt/openvpn.pid` right after launch
- when the graceful wait times out, `finish` escalates: SIGTERM by pid, 2s grace, then SIGKILL
- the `openvpn_alive` helper checks `/proc/<pid>/cmdline` **argv[0]** for `openvpn` before killing — a recycled pid belonging to another process is never signalled
- pidfile removed alongside the existing config cleanup

## Testing

- Helper matrix under BusyBox ash: no pidfile / dead pid / recycled pid (non-openvpn argv0) → all correctly "not alive", no error leakage
- Live image test: pidfile tracks the real openvpn (pid verified via /proc), full `vpn-reconnect` cycle completes cleanly in ~2s with a new pid, `tun0` up, no escalation warnings on the graceful path
- shellcheck/syntax clean