### PR TITLE
feat: refresh TOKEN-fetched credentials on every service start

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-createauth/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-createauth/run
@@ -15,19 +15,14 @@ if [ -n "${USER:-}" ] && [ -n "${PASS:-}" ]; then
     if [ -n "$token" ]; then
         log "$SCRIPT_NAME" "Both USER/PASS and TOKEN are set - using USER/PASS"
     fi
-    auth_user="$USER"
-    auth_pass="$PASS"
+    log "$SCRIPT_NAME" "Creating VPN authentication file"
+    printf '%s\n' "$USER" > "$authfile"
+    printf '%s\n' "$PASS" >> "$authfile"
+    chmod 0600 "$authfile"
+    chown nordvpn:nordvpn "$authfile"
 elif [ -n "$token" ]; then
     log "$SCRIPT_NAME" "Fetching service credentials from NordVPN API using TOKEN"
-    # Pass the token via a 0600 curl config file, not -u on the command line,
-    # so it never appears in /proc/*/cmdline or ps output
-    curlcfg="$(mktemp /run/xt/curl-auth.XXXXXX)"
-    printf 'user = "token:%s"\n' "$token" > "$curlcfg"
-    creds="$(nord_api_curl "v1/users/services/credentials" -K "$curlcfg")" || creds=""
-    rm -f "$curlcfg"
-    auth_user="$(printf '%s' "$creds" | jq -r '.username // empty' 2>/dev/null || true)"
-    auth_pass="$(printf '%s' "$creds" | jq -r '.password // empty' 2>/dev/null || true)"
-    if [ -z "$auth_user" ] || [ -z "$auth_pass" ]; then
+    if ! fetch_token_credentials; then
         log_error "$SCRIPT_NAME" "CRITICAL ERROR: Could not fetch service credentials with TOKEN (check that the token is valid and not expired) - sleeping infinite"
         sleep infinity
     fi
@@ -36,12 +31,6 @@ else
     log_error "$SCRIPT_NAME" "CRITICAL ERROR: No credentials provided - set USER/PASS or TOKEN - sleeping infinite"
     sleep infinity
 fi
-
-log "$SCRIPT_NAME" "Creating VPN authentication file"
-printf '%s\n' "$auth_user" > "$authfile"
-printf '%s\n' "$auth_pass" >> "$authfile"
-chmod 0600 "$authfile"
-chown nordvpn:nordvpn "$authfile"
 
 log "$SCRIPT_NAME" "Authentication setup completed"
 exit 0

--- a/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-nordvpn/run
@@ -9,6 +9,19 @@ SCRIPT_NAME="SERVICE-NORDVPN"
 
 log "$SCRIPT_NAME" "Starting NordVPN service"
 
+# TOKEN mode: refresh the service credentials on every service start (initial
+# boot, cron rotations, health-check reconnects), so credentials rotated by
+# NordVPN self-heal instead of looping on the stale cached ones forever. If
+# the API is unreachable the cached credentials are kept - a refresh failure
+# must never take down a reconnect that would otherwise succeed.
+if [ -n "$token" ] && { [ -z "${USER:-}" ] || [ -z "${PASS:-}" ]; }; then
+    if fetch_token_credentials; then
+        log "$SCRIPT_NAME" "Service credentials refreshed from NordVPN API"
+    else
+        log_warning "$SCRIPT_NAME" "Could not refresh service credentials from NordVPN API - using cached credentials"
+    fi
+fi
+
 # -------- helpers --------
 normalize_proto()
 {

--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -97,6 +97,28 @@ nord_api_curl()
     return "$_rc"
 }
 
+# Fetch the OpenVPN service credentials from the NordVPN API using TOKEN and
+# write them to $authfile (0600). The token travels in a 0600 curl config file,
+# never on the command line. Returns 1 - leaving any existing authfile
+# untouched - when TOKEN is unset or the fetch/parse fails.
+fetch_token_credentials() {
+    [ -n "$token" ] || return 1
+    _curlcfg="$(mktemp /run/xt/curl-auth.XXXXXX)" || return 1
+    printf 'user = "token:%s"\n' "$token" > "$_curlcfg"
+    _creds="$(nord_api_curl "v1/users/services/credentials" -K "$_curlcfg")" || _creds=""
+    rm -f "$_curlcfg"
+    _u="$(printf '%s' "$_creds" | jq -r '.username // empty' 2>/dev/null || true)"
+    _p="$(printf '%s' "$_creds" | jq -r '.password // empty' 2>/dev/null || true)"
+    if [ -z "$_u" ] || [ -z "$_p" ]; then
+        return 1
+    fi
+    printf '%s\n' "$_u" > "$authfile"
+    printf '%s\n' "$_p" >> "$authfile"
+    chmod 0600 "$authfile"
+    chown nordvpn:nordvpn "$authfile"
+    return 0
+}
+
 # Best-effort by design: always returns 0 so plain call sites under `set -e`
 # never abort the caller. Use run4_check when the caller needs the real status.
 run4() {


### PR DESCRIPTION
## Summary

Closes the biggest functional gap in the new `TOKEN` feature: `init-createauth` is a oneshot, so the fetched service credentials were cached in `/run/xt/auth` for the container's entire life. If NordVPN rotated them (or the pair was otherwise invalidated), every reconnect looped on the stale credentials forever, with nothing pointing at the token.

Changes:
- `fetch_token_credentials()` in `backend-functions`: fetches via `nord_api_curl`, token passed in a 0600 curl config file (never on the command line), writes `$authfile` atomically-enough (only on successful parse), returns 1 leaving the existing file untouched on any failure
- `init-createauth` uses the shared function (initial fetch stays fatal — no credentials means no VPN)
- `svc-nordvpn/run` calls it non-fatally on **every service start** — boot, `RECREATE_VPN_CRON` rotations, health-check reconnects — so rotated credentials self-heal; on API failure it logs a warning and keeps the cached pair

**Stacked on #1246** (token-off-cmdline fix) — merge that first; this PR then shows only its own commit.

## Testing (live, rebuilt image)

- Token boot: initial fetch + refresh + connect all work
- Rotation simulation: cached authfile overwritten with stale credentials, then `vpn-reconnect` — credentials re-fetched from the API, stale pair replaced, tunnel re-established
- shellcheck/syntax clean