### PR TITLE
feat: publish selected server as /run/xt/status.json

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -637,5 +637,28 @@ fi
 # Move into place atomically (preserves the 0600 nordvpn:nordvpn ownership)
 mv "$build_file" "$ovpnfile"
 
+# Publish the selection as machine-readable JSON for monitoring/dashboards.
+# Written only after the config is in place, so the file always describes the
+# server the (next) connection actually uses. Best-effort: a write failure
+# must not break configuration.
+load="$(echo "$servers" | jq -r '.load // 0' | head -n 1 || true)"
+if jq -n \
+    --arg name "$name" \
+    --arg hostname "$hostname" \
+    --arg ip "$serverip" \
+    --arg protocol "$protocol" \
+    --arg technology "$technology" \
+    --arg country "$country_name" \
+    --arg city "$city_name" \
+    --argjson load "${load:-0}" \
+    --arg selected_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+    '{name: $name, hostname: $hostname, ip: $ip, protocol: $protocol,
+      technology: $technology, country: $country, city: $city, load: $load,
+      selected_at: $selected_at}' > /run/xt/status.json 2>/dev/null; then
+    chmod 0644 /run/xt/status.json 2>/dev/null || true
+else
+    log_warning "$SCRIPT_NAME" "Could not write /run/xt/status.json"
+fi
+
 log "$SCRIPT_NAME" "VPN configuration completed"
 exit 0

--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -137,6 +137,7 @@ Located in `/usr/local/share/nordvpn/data/`:
 | `/run/xt/nordvpn.ovpn` | Current server's OpenVPN config |
 | `/run/xt/auth` | Credentials file (0600) |
 | `/run/xt/mgmt-pw` | Management interface password |
+| `/run/xt/status.json` | Last selected server as JSON (name, hostname, ip, protocol, technology, country, city, load, selected_at) — world-readable, for monitoring, e.g. `docker exec vpn cat /run/xt/status.json` |
 
 ## OpenVPN Management Interface
 


### PR DESCRIPTION
## Summary

Adds a machine-readable status file for monitoring and dashboards. `vpn-config` already computed the selected server's name, hostname, IP, protocol, country, city and load — it just only logged them. Now it also writes `/run/xt/status.json` (0644) right after the config is atomically moved into place, so the file always describes the server the next connection uses:

```json
{"name":"United States #14161","hostname":"us14161.nordvpn.com","ip":"...","protocol":"udp","technology":"OpenVPN UDP","country":"United States","city":"Chicago","load":18,"selected_at":"2026-08-11T20:58:31Z"}
```

- Built with `jq -n --arg` so values are always correctly JSON-escaped
- Best-effort: a write failure logs a warning, never breaks configuration
- Usage: `docker exec vpn cat /run/xt/status.json` — documented in the Architecture wiki state-file table

## Testing

- Live image test (token mode): file present 0644, valid JSON, values match the connected server
- shellcheck/syntax clean