### PR TITLE
docs(wiki): remove stale --data-ciphers auto-injection claims

### DIFF
--- a/wiki/Architecture-and-Internals.md
+++ b/wiki/Architecture-and-Internals.md
@@ -77,7 +77,7 @@ Location: `/etc/s6-overlay/s6-rc.d/svc-nordvpn/run`
 1. Calls `vpn-config` to get server configuration
 2. Extracts VPN server IP/port/protocol from the OVPN file
 3. Adds temporary firewall rules in `VPN-SERVER` chain for every `remote` line (XOR configs have multiple ports)
-4. Appends `--data-ciphers` if not already set
+4. Writes `OPENVPN_OPTS` to a config fragment OpenVPN parses directly
 5. Launches OpenVPN with auth, management port, and nordvpn group
 6. Waits for tun0 interface (up to 60 seconds)
 7. Optionally runs network diagnostics

--- a/wiki/OpenVPN-Options.md
+++ b/wiki/OpenVPN-Options.md
@@ -1,14 +1,12 @@
 The `OPENVPN_OPTS` environment variable lets you pass additional flags directly to the OpenVPN process. This page documents the default behavior and commonly useful options.
 
-## Default Cipher Configuration
+## Cipher Configuration
 
-The container automatically appends `--data-ciphers` if it's not already present in your `OPENVPN_OPTS`:
+The container does **not** modify OpenVPN's cipher negotiation — it uses the settings from NordVPN's own configuration template. If you see cipher deprecation notices in the logs (e.g. about `AES-256-CBC`), they originate from the config file and are safe to ignore; see the [FAQ](FAQ#logs--messages) for details. To customize negotiation, pass your own list via `OPENVPN_OPTS`:
 
 ```
---data-ciphers AES-256-CBC:AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305
+--data-ciphers AES-256-GCM:AES-128-GCM:CHACHA20-POLY1305:AES-256-CBC
 ```
-
-This prevents OpenVPN cipher deprecation warnings. To override, specify your own `--data-ciphers` in `OPENVPN_OPTS` — the container won't add the default if the flag is already present.
 
 ## How OpenVPN Is Launched
 


### PR DESCRIPTION
## Summary

Wiki-only. The `--data-ciphers` auto-injection was removed from `svc-nordvpn/run` in #1190, and the FAQ was updated at that time — but two pages still claimed the container appends the flag automatically, directly contradicting the FAQ:

- `OpenVPN-Options.md` — "Default Cipher Configuration" section rewritten: the container does **not** touch cipher negotiation (template settings used as-is), deprecation notices are explained with a link to the FAQ's *Logs & Messages* section, and the `--data-ciphers` example is kept as a user-side `OPENVPN_OPTS` override
- `Architecture-and-Internals.md` — the `svc-nordvpn/run` step list no longer lists "Appends `--data-ciphers`"; it now describes the actual `OPENVPN_OPTS` config-fragment mechanism

Verified against `root/`: zero occurrences of `data-ciphers` anywhere in the image code.