### PR TITLE
docs(wiki): align quoted log strings with actual output

### DIFF
--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -31,7 +31,7 @@ The `TECHNOLOGY` variable accepts the following values:
 No. NordVPN does not support inbound port forwarding. You can only access services from your LAN by publishing ports on the VPN container and setting `NETWORK` to include your LAN CIDR.
 
 **Q: How do I know which server I'm connected to?**
-Check the container logs: `docker logs vpn | grep "Server:"`. Or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
+Check the container logs: `docker logs vpn | grep "Selected server:"`. Or run the network diagnostic: `docker exec vpn /usr/local/bin/network-diagnostic --basic`.
 
 **Q: Can I connect to a specific server?**
 Yes. Use the server hostname in `COUNTRY` or `CITY`: `-e COUNTRY=es1234` or `-e CITY=uk2567`. Specific servers get priority with `load=0`.
@@ -64,7 +64,7 @@ The kill switch blocks all traffic except `NETWORK` CIDRs and NordVPN API IPs. I
 Yes. The image supports `arm/v6`, `arm/v7`, and `arm64`. Docker pulls the correct architecture automatically.
 
 **Q: Does this work on Synology / QNAP NAS?**
-Generally yes, but some NAS devices have older kernels or limited iptables support. The container auto-detects nft vs legacy backends. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to verify.
+Generally yes, but some NAS devices have older kernels or limited iptables support. The container auto-detects nft vs legacy backends. Check logs for `[ENTRYPOINT] Using iptables backend:` to verify.
 
 **Q: What's the difference between Docker Hub and GHCR images?**
 They are identical. Use whichever registry is more convenient: `azinchen/nordvpn` (Docker Hub) or `ghcr.io/azinchen/nordvpn` (GitHub Container Registry).

--- a/wiki/Firewall-Backends.md
+++ b/wiki/Firewall-Backends.md
@@ -12,13 +12,13 @@ This image ships **both** `iptables` (nft-backed) and `iptables-legacy` (xtables
 On newer kernels:
 ```
 [ENTRYPOINT] Kernel: 6.8.0-xx
-[ENTRYPOINT] Using IPv4 backend: iptables
+[ENTRYPOINT] Using iptables backend: iptables
 ```
 
 On older systems:
 ```
 [ENTRYPOINT] Kernel: 4.4.0-xxx
-[ENTRYPOINT] Using IPv4 backend: iptables-legacy
+[ENTRYPOINT] Using iptables backend: iptables-legacy
 ```
 
 ## Why This Matters

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -87,7 +87,7 @@ Docker subnets are **not** auto-allowed. If inter-container communication is nee
 
 **Check:**
 1. **NET_ADMIN capability:** Ensure `--cap-add=NET_ADMIN` is set.
-2. **Kernel compatibility:** The container auto-detects nft vs legacy. Check logs for `[ENTRYPOINT] Using IPv4 backend:` to see which was selected.
+2. **Kernel compatibility:** The container auto-detects nft vs legacy. Check logs for `[ENTRYPOINT] Using iptables backend:` to see which was selected.
 3. **Host iptables modules:** Some minimal hosts (e.g., certain NAS devices) may lack required kernel modules.
 
 ## Technologies
@@ -153,11 +153,11 @@ Key log messages:
 
 | Log message | Meaning |
 |------------|---------|
-| `[ENTRYPOINT] Using IPv4 backend: ...` | Firewall backend selected |
-| `[VPN-CONFIG] Server: ...` | Selected VPN server |
+| `[ENTRYPOINT] Using iptables backend: ...` | Firewall backend selected |
+| `[VPN-CONFIG] Selected server: ...` | Selected VPN server |
 | `Initialization Sequence Completed` | OpenVPN connected successfully |
-| `[HEALTHCHECK] Connection check failed` | Health check triggered reconnection |
-| `[VPN-RECONNECT] Reconnecting...` | Service restarting |
+| `[VPN-HEALTHCHECK] All connection attempts failed, triggering VPN reconnection` | Health check triggered reconnection |
+| `[VPN-RECONNECT] Starting VPN reconnection` | Service restarting |
 
 ### Inspecting the Container
 


### PR DESCRIPTION
## Summary

Wiki-only. Four pages quoted log messages that the scripts never actually print, so copy-pasted `grep` checks silently matched nothing:

| Documented (wrong) | Actual (verified in code) |
|---|---|
| `[ENTRYPOINT] Using IPv4 backend:` | `[ENTRYPOINT] Using iptables backend:` (`entrypoint:100`) |
| `docker logs vpn \| grep "Server:"` | `Selected server:` (`vpn-config:542` — lowercase 'server' made the old case-sensitive grep miss) |
| `[HEALTHCHECK] Connection check failed` | `[VPN-HEALTHCHECK] All connection attempts failed, triggering VPN reconnection` |
| `[VPN-RECONNECT] Reconnecting...` | `[VPN-RECONNECT] Starting VPN reconnection` |

Touched: `FAQ.md`, `Troubleshooting.md` (including the Key log messages table), `Firewall-Backends.md` (sample output blocks).