### PR TITLE
docs: add TOKEN examples and fix example port mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,13 @@ services:
     environment:
       - USER=service_username
       - PASS=service_password
+      # - TOKEN=access_token       # alternative to USER/PASS
       - COUNTRY=United States;CA
       - RANDOM_TOP=10
       - RECREATE_VPN_CRON=0 */6 * * *
       - NETWORK=192.168.1.0/24
     ports:
-      - "8080:8080"
+      - "8080:80"                  # host:container — use your app's listening port
     restart: unless-stopped
 
   app:

--- a/wiki/Docker-Compose-Examples.md
+++ b/wiki/Docker-Compose-Examples.md
@@ -12,13 +12,14 @@ services:
     environment:
       - USER=service_username
       - PASS=service_password
+      # - TOKEN=access_token       # alternative to USER/PASS
       - COUNTRY=United States;CA;38
       - CITY=New York;Los Angeles;Toronto
       - RANDOM_TOP=10
       - RECREATE_VPN_CRON=0 */6 * * *
       - NETWORK=192.168.1.0/24
-    ports:
-      - "8080:8080"
+    ports:                         # host:container — use your apps' listening ports
+      - "8080:80"                  # nginx below listens on 80
       - "3000:3000"
     restart: unless-stopped
 
@@ -68,8 +69,8 @@ services:
       - CHECK_CONNECTION_URL=https://1.1.1.1;https://8.8.8.8
       - NETWORK=192.168.1.0/24;172.20.0.0/16
       - OPENVPN_OPTS=--mute-replay-warnings --ping-exit 60
-    ports:
-      - "8080:8080"
+    ports:                         # host:container — use your apps' listening ports
+      - "8080:80"                  # nginx below listens on 80
       - "3000:3000"
       - "9000:9000"
       - "6379:6379"
@@ -194,7 +195,7 @@ services:
       - CHECK_CONNECTION_CRON=*/5 * * * *
       - NETWORK=192.168.1.0/24
     ports:
-      - "8080:8080"
+      - "8080:80"                  # host:container — nginx below listens on 80
     restart: unless-stopped
 
   app:

--- a/wiki/Docker-Run-Examples.md
+++ b/wiki/Docker-Run-Examples.md
@@ -12,13 +12,23 @@ docker run -d --name vpn \
 docker run -d --name app --net=container:vpn nginx
 ```
 
+With an access token instead of service credentials (see [Getting Service Credentials](https://github.com/azinchen/nordvpn#getting-service-credentials)):
+
+```bash
+docker run -d --name vpn \
+           --cap-add=NET_ADMIN \
+           --device /dev/net/tun \
+           -e TOKEN=access_token \
+           azinchen/nordvpn
+```
+
 ## Advanced Example with Port Mapping
 
 ```bash
 docker run -d --name vpn \
            --cap-add=NET_ADMIN \
            --device /dev/net/tun \
-           -p 8080:8080 \
+           -p 8080:80 \
            -p 9091:9091 \
            -e USER=service_username \
            -e PASS=service_password \
@@ -54,7 +64,7 @@ Use XOR obfuscation to bypass deep packet inspection. See [Technologies](Technol
 docker run -d --name vpn \
            --cap-add=NET_ADMIN \
            --device /dev/net/tun \
-           -p 8080:8080 \
+           -p 8080:80 \
            -e USER=service_username \
            -e PASS=service_password \
            -e TECHNOLOGY=openvpn_xor_tcp \


### PR DESCRIPTION
## Summary

- **TOKEN examples:** the README compose example, the wiki compose examples, and the wiki run examples now show the `TOKEN` alternative (commented line in compose, dedicated snippet in Docker-Run-Examples) — previously only the README quick-start and FAQ mentioned it.
- **Port mappings:** examples paired `nginx:alpine` (listens on 80) with `"8080:8080"`, so the copy-pasted stack never reached the app. Changed to `"8080:80"` with `host:container` comments; generic extra ports (3000/9000/6379) kept with a clarifying comment.

Touched: `README.md`, `wiki/Docker-Compose-Examples.md`, `wiki/Docker-Run-Examples.md`.

(Note: the repo-root `docker-compose.yml` is gitignored/untracked — a local test file — so it is deliberately not part of this PR; the commit message's mention of it refers to a local-only cleanup that turned out to be unnecessary.)