### PR TITLE
ci: verify apk bumps across all build arches; fix scan comment; align Dockerfile arch mappings

### DIFF
--- a/.github/workflows/security-docker.yml
+++ b/.github/workflows/security-docker.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # Run at 6 AM UTC daily to check latest production image on Docker Hub
+    - cron: '0 6 * * *'  # Run at 6 AM UTC daily to check the latest production image on GHCR (same digest as Docker Hub)
   workflow_dispatch:
     inputs:
       image_tag:
@@ -46,7 +46,7 @@ jobs:
           REGISTRY="ghcr"
           IMAGE_REF="ghcr.io/${{ github.repository }}:${IMAGE_TAG}"
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            # Cron job: Always scan latest production image on 
+            # Cron job: Always scan the latest production image on GHCR
             IMAGE_TAG="latest"
             echo "🕒 Scheduled scan: Checking latest production image on GHCR"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,15 @@ RUN echo "**** install security fix packages ****" && \
     echo "**** download ${PACKAGE} ****" && \
     echo "Target arch: ${TARGETARCH}${TARGETVARIANT}" && \
     # Map Docker TARGETARCH to s6-overlay architecture names
+    # All platforms supported by BOTH Alpine and s6-overlay; the published
+    # subset is defined by PLATFORMS in ci-build-deploy.yml. (loongarch64 has
+    # no s6-overlay binaries; big-endian ppc64 has no Alpine port.)
     case "${TARGETARCH}${TARGETVARIANT}" in \
         amd64)      s6_arch="x86_64" ;; \
         arm64)      s6_arch="aarch64" ;; \
         armv7)      s6_arch="arm" ;; \
         armv6)      s6_arch="armhf" ;; \
         386)        s6_arch="i686" ;; \
-        ppc64)      s6_arch="powerpc64" ;; \
         ppc64le)    s6_arch="powerpc64le" ;; \
         riscv64)    s6_arch="riscv64" ;; \
         s390x)      s6_arch="s390x" ;; \

--- a/scripts/update-apk-versions.sh
+++ b/scripts/update-apk-versions.sh
@@ -129,6 +129,28 @@ extract_new_version()
     echo "$version"
 }
 
+# Architectures the image is built for (PLATFORMS in ci-build-deploy.yml),
+# mapped to Alpine repository architecture names.
+BUILD_ARCHES="x86 x86_64 armhf armv7 aarch64 riscv64"
+
+# Print the build architectures where pkg=version is NOT available in repo.
+# Empty output means the version exists everywhere; used to hold back updates
+# that Alpine has not yet built for all architectures we ship.
+missing_arches_for_version()
+{
+    local pkg="$1" repo="$2" version="$3"
+    local missing=""
+    for arch in $BUILD_ARCHES; do
+        [ "$arch" = "x86_64" ] && continue    # source of $version, already known
+        local v
+        v=$(extract_new_version "https://pkgs.alpinelinux.org/package/v${ALPINE_BRANCH}/${repo}/${arch}/${pkg}")
+        if [ "$v" != "$version" ]; then
+            missing="$missing $arch"
+        fi
+    done
+    echo "$missing"
+}
+
 # --- 3b. Function to Map TARGETPLATFORM to Alpine Package Repository Architecture ---
 # Based on TARGETPLATFORM values from Docker buildx and actual Alpine repository usage:
 # - linux/amd64    -> x86_64
@@ -264,6 +286,13 @@ update_package_with_tracking() {
     fi
 
     if [ "$current_version" != "$new_version" ]; then
+        # Hold back the bump until Alpine has built it for every architecture
+        # we ship - x86_64 availability alone can break the multi-arch build
+        missing=$(missing_arches_for_version "$pkg" "$repo" "$new_version")
+        if [ -n "$missing" ]; then
+            echo "  ⚠ $new_version not yet available on:$missing - keeping $current_version"
+            return
+        fi
         echo "  → Updating to $new_version (from $repo)"
         # Match package=version followed by whitespace or backslash to ensure we match the complete version
         sed -i "s/\(${pkg}=\)${current_version}\([[:space:]\\]\)/\1${new_version}\2/" "$DOCKERFILE"

--- a/wiki/Supported-Platforms.md
+++ b/wiki/Supported-Platforms.md
@@ -1,6 +1,8 @@
 This image supports multiple CPU architectures. Docker will automatically pull the correct image for your platform.
 
-## Available Architectures
+## Published Architectures
+
+The images on Docker Hub and GHCR are built for the platforms listed in the CI configuration (`PLATFORMS` in `ci-build-deploy.yml`):
 
 | Architecture | Platform |
 |--------------|----------|
@@ -10,6 +12,16 @@ This image supports multiple CPU architectures. Docker will automatically pull t
 | `arm/v7` | ARM v7 (Raspberry Pi 2/3) |
 | `arm64` | 64-bit ARM (Raspberry Pi 4/5, Apple M1) |
 | `riscv64` | 64-bit RISC-V |
+
+## Buildable Architectures
+
+The Dockerfile itself supports every platform that **both** Alpine Linux and s6-overlay provide — the published list above plus `ppc64le` and `s390x`. Those two aren't published (no known demand), but you can build them locally:
+
+```bash
+docker buildx build --platform linux/ppc64le -t nordvpn:ppc64le .
+```
+
+(`loongarch64` is excluded — Alpine ships it but s6-overlay has no binaries; big-endian `ppc64` is excluded — s6-overlay ships it but Alpine has no port.)
 
 ## Automatic Architecture Detection
 


### PR DESCRIPTION
## Summary

Three CI/build hygiene fixes (scope of the Dockerfile part updated after review — mappings now cover the full Alpine ∩ s6-overlay support matrix instead of being trimmed to the CI list):

1. **Multi-arch safety for apk bumps** (`scripts/update-apk-versions.sh`): the updater validated new package versions against x86_64 only, while the published image ships for 6 architectures. Alpine occasionally lags a package build on slower arches, so an automated PR could bump to a version that breaks the multi-arch build. New `missing_arches_for_version()` checks every **published** build arch (from `PLATFORMS`) and holds back the bump with a log line when any arch lacks it.
2. **`security-docker.yml`**: the schedule comment said the daily scan checks Docker Hub, but the code always scans GHCR (plus one truncated comment). Comments now match the code; both registries share the same digest.
3. **`Dockerfile` arch mappings**: now exactly the platforms supported by **both** Alpine 3.24 and s6-overlay 3.2.3.2 (verified against the Alpine repo index and the s6-overlay release assets): the published set plus `ppc64le` and `s390x`. Big-endian `ppc64` is dropped — s6-overlay ships it but **Alpine has no port**, so it could never build. `loongarch64` stays excluded (Alpine yes, s6-overlay no). The published subset remains defined by `PLATFORMS` in `ci-build-deploy.yml`.
4. **Wiki `Supported-Platforms`**: now documents *published* architectures (the CI list) vs *buildable* architectures (Alpine ∩ s6-overlay, incl. local buildx example for `ppc64le`/`s390x`) and why `loongarch64`/`ppc64` are excluded.

## Testing

- `missing_arches_for_version` exercised against the live Alpine package site (current `curl`: available everywhere; fake version: all 5 non-x86_64 arches reported missing)
- amd64 image builds; **ppc64le s6-builder stage cross-builds successfully** via buildx (validates the restored mapping end-to-end through the s6-overlay download)
- Script passes BusyBox syntax check