### PR TITLE
fix: use the password, not the username, in mgmt_cmd fallback

### DIFF
--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -185,8 +185,10 @@ mgmt_cmd() {
     if [ -f "$mgmtpwfile" ]; then
         _pw="$(cat "$mgmtpwfile" 2>/dev/null)"
     else
-        # Fallback to environment variables (user/pass from backend or USER/PASS env)
-        _pw="${user:-${USER:-}}"
+        # Fallback: the management password is set from the service-credential
+        # password (see init-createmgmtpwfile), so fall back to that - not the
+        # username, which would always fail auth
+        _pw="${pass:-${PASS:-}}"
     fi
     
     if [ -z "$_pw" ]; then


### PR DESCRIPTION
## Summary

Latent bug in `backend-functions`: when `/run/xt/mgmt-pw` is missing, `mgmt_cmd` fell back to `${user:-${USER:-}}` — the service-credential **username** — as the management password. The file is written from the **password** (`mgmt_pw="$pass"` in `init-createmgmtpwfile`), so the fallback was guaranteed to fail authentication whenever it fired. Nearly dead code in practice (the file exists after init), but wrong when it matters.

Fix: fall back to `${pass:-${PASS:-}}`. In TOKEN mode this still works because `backend-functions` resolves `pass` from the fetched credentials in the auth file.

## Testing

Live: connected container, moved `mgmt-pw` away, called `mgmt_cmd state` → `CONNECTED,SUCCESS` via the fallback path (previously would have failed auth).