### PR TITLE
feat: sectioned layout for the groups and technologies wiki lists

### DIFF
--- a/.github/workflows/maintenance-updates.yml
+++ b/.github/workflows/maintenance-updates.yml
@@ -88,7 +88,7 @@ jobs:
               COUNTRIES_JSON=$(curl -s "https://api.nordvpn.com/v1/servers/countries")
               VIRTUAL_IDS=$(curl -s "https://api.nordvpn.com/v1/servers?limit=0" \
                 | jq -c '[.[] | select(any(.specifications[]?; .identifier=="virtual_location" and .values[0].value=="true")) | .locations[0].country.city.id] | unique')
-              BODY=$(echo "$COUNTRIES_JSON" | jq -r --argjson virtual "${VIRTUAL_IDS:-[]}" '[.[] | . as $parent | .cities[] | . as $city | {flag: ($parent.code | explode | map(. + 127397) | implode), country: $parent.name, code: $parent.code, city: $city.name, cityid: $city.id, virt: (if ($virtual | index($city.id)) then "🌐 Virtual" else "✅ Physical" end), lat: $city.latitude, lon: $city.longitude}] | sort_by(.country, .city) | .[] | "| \(.flag) | \(.country) | \(.code) | \(.city) | \(.cityid) | \(.virt) | [📍](https://www.google.com/maps?q=\(.lat),\(.lon)) |"')
+              BODY=$(echo "$COUNTRIES_JSON" | jq -r --argjson virtual "${VIRTUAL_IDS:-[]}" '[.[] | . as $parent | .cities[] | . as $city | {flag: ($parent.code | explode | map(. + 127397) | implode), country: $parent.name, code: $parent.code, city: $city.name, cityid: $city.id, virt: (if ($virtual | index($city.id)) then "🌐 Virtual" else "✅ Physical" end), lat: ($city.latitude + 0), lon: ($city.longitude + 0)}] | sort_by(.country, .city) | .[] | "| \(.flag) | \(.country) | \(.code) | \(.city) | \(.cityid) | \(.virt) | [📍](https://www.google.com/maps?q=\(.lat),\(.lon)) |"')
               TOTAL=$(echo "$COUNTRIES_JSON" | jq '[.[].cities[]] | length')
               CCNT=$(echo "$COUNTRIES_JSON" | jq 'length')
               STATS="${TOTAL} cities in ${CCNT} countries"
@@ -100,39 +100,81 @@ jobs:
             TECHNOLOGIES)
               TECH_JSON=$(curl -s "https://api.nordvpn.com/v1/technologies")
               ACTIVE=$(curl -s "https://api.nordvpn.com/v1/servers?limit=0" | jq -c '[.[].technologies[].identifier] | unique')
-              BODY=$(echo "$TECH_JSON" | jq -r --argjson active "${ACTIVE:-[]}" '.[] | .identifier as $ident | "| \(.name) | \($ident) | \(.id) | \(if ($ident | startswith("openvpn")) then (if ($active | index($ident)) then "✅" else "⚠️ No servers" end) else "—" end) |"')
+              SUPP_BODY=$(echo "$TECH_JSON" | jq -r --argjson active "${ACTIVE:-[]}" '.[] | select(.identifier as $i | ($i | startswith("openvpn")) and ($active | index($i))) | "| \(.name) | \(.identifier) | \(.id) |"')
+              OTHER_BODY=$(echo "$TECH_JSON" | jq -r --argjson active "${ACTIVE:-[]}" '.[] | select(.identifier as $i | (($i | startswith("openvpn")) and ($active | index($i))) | not) | "| \(.name) | \(.identifier) | \(.id) | \(if (.identifier | startswith("openvpn")) then "no servers in the fleet" else "non-OpenVPN" end) |"')
               TOTAL=$(echo "$TECH_JSON" | jq 'length')
               SUPP=$(echo "$TECH_JSON" | jq --argjson active "${ACTIVE:-[]}" '[.[] | select(.identifier as $i | ($i | startswith("openvpn")) and ($active | index($i)))] | length')
               STATS="${TOTAL} technologies (${SUPP} supported by this image)"
-              INTRO='Values for the `TECHNOLOGY` variable — name, identifier, or ID: `-e TECHNOLOGY=openvpn_xor_udp`'
-              NOTE='> ✅ Supported by this image · ⚠️ OpenVPN-based but currently no servers in the fleet · — not supported (non-OpenVPN). XOR and Dedicated IP technologies additionally require the matching `GROUP` — see [Technologies](Technologies).'
-              HEADER='| Technology | Identifier | ID | Supported |'
+              PAGE_BODY="Values for the \`TECHNOLOGY\` variable — name, identifier, or ID: \`-e TECHNOLOGY=openvpn_xor_udp\`
+
+          ## Supported by this image
+
+          > XOR and Dedicated IP technologies additionally require the matching \`GROUP\` — see [Technologies](Technologies).
+
+          | Technology | Identifier | ID |
+          |------------|------------|----|
+          ${SUPP_BODY}
+
+          ## Other technologies
+
+          Non-OpenVPN protocols and OpenVPN variants without servers — not usable with this image.
+
+          <details>
+          <summary>Show all ($((TOTAL - SUPP)))</summary>
+
+          | Technology | Identifier | ID | Why not |
+          |------------|------------|----|---------|
+          ${OTHER_BODY}
+
+          </details>"
               LINKS='See [Technologies](Technologies) · [Countries List](Countries-List) · [Cities List](Cities-List) · [Groups List](Groups-List)'
               ;;
             GROUPS)
               GROUPS_JSON=$(curl -s "https://api.nordvpn.com/v1/servers/groups")
-              BODY=$(echo "$GROUPS_JSON" | jq -r '.[] | "| \(.title) | \(.identifier) | \(.id) |"')
+              ACTIVE=$(curl -s "https://api.nordvpn.com/v1/servers?limit=0" | jq -c '[.[].groups[].id] | unique')
+              CAT_BODY=$(echo "$GROUPS_JSON" | jq -r --argjson act "${ACTIVE:-[]}" '.[] | select(.type.identifier=="legacy_group_category") | .id as $i | "| \(.title) | \(.identifier) | \($i) | \(if ($act | index($i)) then "✅" else "—" end) |"')
+              REG_BODY=$(echo "$GROUPS_JSON" | jq -r --argjson act "${ACTIVE:-[]}" '.[] | select(.type.identifier=="regions") | .id as $i | "| \(.title) | \(.identifier) | \($i) | \(if ($act | index($i)) then "✅" else "—" end) |"')
               TOTAL=$(echo "$GROUPS_JSON" | jq 'length')
-              STATS="${TOTAL} groups"
-              INTRO='Values for the `GROUP` variable — title, identifier, or ID: `-e GROUP="P2P"`'
-              NOTE='> XOR obfuscation requires `GROUP=legacy_obfuscated_servers`; Dedicated IP requires `GROUP=legacy_dedicated_ip`. See [Server Groups](Server-Groups).'
-              HEADER='| Group | Identifier | ID |'
+              WITH=$(echo "$GROUPS_JSON" | jq --argjson act "${ACTIVE:-[]}" '[.[] | select(.id as $i | $act | index($i))] | length')
+              STATS="${TOTAL} groups (${WITH} with servers)"
+              PAGE_BODY="Values for the \`GROUP\` variable — title, identifier, or ID: \`-e GROUP=\"P2P\"\`
+
+          > ✅ = the group currently has servers in the fleet · — = no servers (internal or retired groups).
+
+          ## Server categories
+
+          > XOR obfuscation requires \`GROUP=legacy_obfuscated_servers\`; Dedicated IP requires \`GROUP=legacy_dedicated_ip\`. See [Server Groups](Server-Groups).
+
+          | Group | Identifier | ID | Servers |
+          |-------|------------|----|---------|
+          ${CAT_BODY}
+
+          ## Regions
+
+          | Group | Identifier | ID | Servers |
+          |-------|------------|----|---------|
+          ${REG_BODY}"
               LINKS='See [Server Groups](Server-Groups) · [Countries List](Countries-List) · [Cities List](Cities-List) · [Technologies List](Technologies-List)'
               ;;
             *)
               echo "unknown page: $NAME" >&2; exit 1 ;;
           esac
 
-          SEP=$(echo "$HEADER" | sed 's/[^|]/-/g')
-
-          # Everything below the timestamp/stats line; used for change detection
-          NEW_CONTENT="${INTRO}
+          # Single-table pages assemble the standard layout; sectioned pages
+          # (GROUPS, TECHNOLOGIES) build PAGE_BODY themselves in their case branch
+          if [ -z "${PAGE_BODY:-}" ]; then
+              SEP=$(echo "$HEADER" | sed 's/[^|]/-/g')
+              PAGE_BODY="${INTRO}
 
           ${NOTE}
 
           ${HEADER}
           ${SEP}
-          ${BODY}
+          ${BODY}"
+          fi
+
+          # Everything below the timestamp/stats line; used for change detection
+          NEW_CONTENT="${PAGE_BODY}
 
           ---
           ${FOOTER}

--- a/wiki/Groups-List.md
+++ b/wiki/Groups-List.md
@@ -1,30 +1,39 @@
-_Last updated: 2026-08-11 · 19 groups_
+_Last updated: 2026-08-11 · 19 groups (10 with servers)_
 
 Values for the `GROUP` variable — title, identifier, or ID: `-e GROUP="P2P"`
 
+> ✅ = the group currently has servers in the fleet · — = no servers (internal or retired groups).
+
+## Server categories
+
 > XOR obfuscation requires `GROUP=legacy_obfuscated_servers`; Dedicated IP requires `GROUP=legacy_dedicated_ip`. See [Server Groups](Server-Groups).
 
-| Group | Identifier | ID |
-|-------|------------|----|
-| Double VPN | legacy_double_vpn | 1 |
-| Onion Over VPN | legacy_onion_over_vpn | 3 |
-| Ultra fast TV | legacy_ultra_fast_tv | 5 |
-| Anti DDoS | legacy_anti_ddos | 7 |
-| Dedicated IP | legacy_dedicated_ip | 9 |
-| Standard VPN servers | legacy_standard | 11 |
-| Netflix USA | legacy_netflix_usa | 13 |
-| P2P | legacy_p2p | 15 |
-| Obfuscated Servers | legacy_obfuscated_servers | 17 |
-| Europe | europe | 19 |
-| The Americas | the_americas | 21 |
-| Asia Pacific | asia_pacific | 23 |
-| Africa, the Middle East and India | africa_the_middle_east_and_india | 25 |
-| Anycast DNS | anycast-dns | 233 |
-| Geo DNS | geo_dns | 236 |
-| Grafana | grafana | 239 |
-| Kapacitor | kapacitor | 242 |
-| Socks5 Proxy | legacy_socks5_proxy | 245 |
-| FastNetMon | fastnetmon | 248 |
+| Group | Identifier | ID | Servers |
+|-------|------------|----|---------|
+| Double VPN | legacy_double_vpn | 1 | ✅ |
+| Onion Over VPN | legacy_onion_over_vpn | 3 | ✅ |
+| Ultra fast TV | legacy_ultra_fast_tv | 5 | — |
+| Anti DDoS | legacy_anti_ddos | 7 | — |
+| Dedicated IP | legacy_dedicated_ip | 9 | ✅ |
+| Standard VPN servers | legacy_standard | 11 | ✅ |
+| Netflix USA | legacy_netflix_usa | 13 | — |
+| P2P | legacy_p2p | 15 | ✅ |
+| Obfuscated Servers | legacy_obfuscated_servers | 17 | ✅ |
+| Anycast DNS | anycast-dns | 233 | — |
+| Geo DNS | geo_dns | 236 | — |
+| Grafana | grafana | 239 | — |
+| Kapacitor | kapacitor | 242 | — |
+| Socks5 Proxy | legacy_socks5_proxy | 245 | — |
+| FastNetMon | fastnetmon | 248 | — |
+
+## Regions
+
+| Group | Identifier | ID | Servers |
+|-------|------------|----|---------|
+| Europe | europe | 19 | ✅ |
+| The Americas | the_americas | 21 | ✅ |
+| Asia Pacific | asia_pacific | 23 | ✅ |
+| Africa, the Middle East and India | africa_the_middle_east_and_india | 25 | ✅ |
 
 ---
 _Generated from the NordVPN API; this page reflects the server lists baked into the latest released image._

--- a/wiki/Technologies-List.md
+++ b/wiki/Technologies-List.md
@@ -2,34 +2,48 @@ _Last updated: 2026-08-11 · 24 technologies (6 supported by this image)_
 
 Values for the `TECHNOLOGY` variable — name, identifier, or ID: `-e TECHNOLOGY=openvpn_xor_udp`
 
-> ✅ Supported by this image · ⚠️ OpenVPN-based but currently no servers in the fleet · — not supported (non-OpenVPN). XOR and Dedicated IP technologies additionally require the matching `GROUP` — see [Technologies](Technologies).
+## Supported by this image
 
-| Technology | Identifier | ID | Supported |
-|------------|------------|----|-----------|
-| IKEv2/IPSec | ikev2 | 1 | — |
-| OpenVPN UDP | openvpn_udp | 3 | ✅ |
-| OpenVPN TCP | openvpn_tcp | 5 | ✅ |
-| Socks 5 | socks | 7 | — |
-| HTTP Proxy | proxy | 9 | — |
-| PPTP | pptp | 11 | — |
-| L2TP/IPSec | l2tp | 13 | — |
-| OpenVPN UDP Obfuscated | openvpn_xor_udp | 15 | ✅ |
-| OpenVPN TCP Obfuscated | openvpn_xor_tcp | 17 | ✅ |
-| HTTP CyberSec Proxy | proxy_cybersec | 19 | — |
-| HTTP Proxy (SSL) | proxy_ssl | 21 | — |
-| HTTP CyberSec Proxy (SSL) | proxy_ssl_cybersec | 23 | — |
-| IKEv2/IPSec IPv6 | ikev2_v6 | 26 | — |
-| OpenVPN UDP IPv6 | openvpn_udp_v6 | 29 | ⚠️ No servers |
-| OpenVPN TCP IPv6 | openvpn_tcp_v6 | 32 | ⚠️ No servers |
-| Wireguard | wireguard_udp | 35 | — |
-| OpenVPN UDP TLS Crypt | openvpn_udp_tls_crypt | 38 | ⚠️ No servers |
-| OpenVPN TCP TLS Crypt | openvpn_tcp_tls_crypt | 41 | ⚠️ No servers |
-| OpenVPN UDP Dedicated | openvpn_dedicated_udp | 42 | ✅ |
-| OpenVPN TCP Dedicated | openvpn_dedicated_tcp | 45 | ✅ |
-| Skylark | skylark | 48 | — |
-| Mesh Relay | mesh_relay | 50 | — |
-| NordWhisper | nordwhisper | 51 | — |
-| NordWhisper UDP | nordwhisper_udp | 56 | — |
+> XOR and Dedicated IP technologies additionally require the matching `GROUP` — see [Technologies](Technologies).
+
+| Technology | Identifier | ID |
+|------------|------------|----|
+| OpenVPN UDP | openvpn_udp | 3 |
+| OpenVPN TCP | openvpn_tcp | 5 |
+| OpenVPN UDP Obfuscated | openvpn_xor_udp | 15 |
+| OpenVPN TCP Obfuscated | openvpn_xor_tcp | 17 |
+| OpenVPN UDP Dedicated | openvpn_dedicated_udp | 42 |
+| OpenVPN TCP Dedicated | openvpn_dedicated_tcp | 45 |
+
+## Other technologies
+
+Non-OpenVPN protocols and OpenVPN variants without servers — not usable with this image.
+
+<details>
+<summary>Show all (18)</summary>
+
+| Technology | Identifier | ID | Why not |
+|------------|------------|----|---------|
+| IKEv2/IPSec | ikev2 | 1 | non-OpenVPN |
+| Socks 5 | socks | 7 | non-OpenVPN |
+| HTTP Proxy | proxy | 9 | non-OpenVPN |
+| PPTP | pptp | 11 | non-OpenVPN |
+| L2TP/IPSec | l2tp | 13 | non-OpenVPN |
+| HTTP CyberSec Proxy | proxy_cybersec | 19 | non-OpenVPN |
+| HTTP Proxy (SSL) | proxy_ssl | 21 | non-OpenVPN |
+| HTTP CyberSec Proxy (SSL) | proxy_ssl_cybersec | 23 | non-OpenVPN |
+| IKEv2/IPSec IPv6 | ikev2_v6 | 26 | non-OpenVPN |
+| OpenVPN UDP IPv6 | openvpn_udp_v6 | 29 | no servers in the fleet |
+| OpenVPN TCP IPv6 | openvpn_tcp_v6 | 32 | no servers in the fleet |
+| Wireguard | wireguard_udp | 35 | non-OpenVPN |
+| OpenVPN UDP TLS Crypt | openvpn_udp_tls_crypt | 38 | no servers in the fleet |
+| OpenVPN TCP TLS Crypt | openvpn_tcp_tls_crypt | 41 | no servers in the fleet |
+| Skylark | skylark | 48 | non-OpenVPN |
+| Mesh Relay | mesh_relay | 50 | non-OpenVPN |
+| NordWhisper | nordwhisper | 51 | non-OpenVPN |
+| NordWhisper UDP | nordwhisper_udp | 56 | non-OpenVPN |
+
+</details>
 
 ---
 _Generated from the NordVPN API; this page reflects the server lists baked into the latest released image._


### PR DESCRIPTION
## Summary

Follow-up beautification for the two structural list pages:

**Groups-List** — split by the API's group type into **Server categories** and **Regions** sections, plus a new **Servers** column (✅/—) computed from the live fleet: it now shows at a glance that `Grafana`, `Kapacitor`, `FastNetMon`, `Anycast DNS`, `Geo DNS` are internal infrastructure and `Netflix USA`, `Ultra fast TV`, `Anti DDoS`, `Socks5 Proxy` have no servers — 10 of 19 groups are actually usable, and the stats line says so.

**Technologies-List** — leads with a **Supported by this image** table (the six OpenVPN technologies with servers, with the `GROUP` requirement note), and folds the other 18 into a collapsible `<details>` section with a *Why not* column (`non-OpenVPN` / `no servers in the fleet`).

**Stability fix found along the way** — modern jq preserves the API's float literals, and NordVPN's serializers are inconsistent about `16.0` vs `16` across requests, so the city map URLs could flap and produce spurious bot diffs. Lat/lon are now normalized via jq arithmetic (`+ 0`) in the generator, making output canonical regardless of which API frontend answers. The committed `Cities-List.md` is deliberately NOT touched here — the next scheduled maintenance run will regenerate it in canonical form as a normal data-update PR.

Countries/Cities keep their existing layout otherwise.

## Testing

- Groups/Technologies pages regenerated from the live API with the updated generator
- Parity matrix: the run block extracted from the workflow YAML reports `has_changes=false` for Groups, Technologies and Countries; Cities will intentionally report changes on the next run (the one-time canonicalization pickup)
- Workflow YAML validated
