### PR TITLE
Fall back to the recommended pool when a group has no matching servers

### DIFF
--- a/root/usr/local/bin/vpn-config
+++ b/root/usr/local/bin/vpn-config
@@ -487,7 +487,9 @@ fi
 if [ "$poollength" -eq 0 ]; then
     log "$SCRIPT_NAME" "Using default recommended servers"
     
-    # Build curl parameters for fallback
+    # Build curl parameters for fallback. GROUP is kept on the first attempt:
+    # when only GROUP is set (no COUNTRY/CITY), this path IS the primary
+    # query, not a fallback.
     curl_params=""
     if [ -n "$tech_filter" ]; then
         curl_params="$tech_filter"
@@ -495,8 +497,16 @@ if [ "$poollength" -eq 0 ]; then
     if [ -n "$group_filter" ]; then
         curl_params="$curl_params $group_filter"
     fi
-    
+
     servers=$(eval "nord_api_curl \"v1/servers/recommendations\" $curl_params 2>/dev/null | jq -c '.[]' 2>/dev/null || echo \"\"")
+
+    # Second stage: a group with no servers for the selected technology yields
+    # an empty response forever - retry once without the group filter so the
+    # container still comes up on the recommended pool instead of failing hard.
+    if [ -z "$servers" ] && [ -n "$group_filter" ]; then
+        log_warning "$SCRIPT_NAME" "No servers in group \"$group\" match TECHNOLOGY=$technology - retrying without the group filter"
+        servers=$(eval "nord_api_curl \"v1/servers/recommendations\" $tech_filter 2>/dev/null | jq -c '.[]' 2>/dev/null || echo \"\"")
+    fi
     
     if [ -n "$servers" ]; then
         log "$SCRIPT_NAME" "Fetched $(echo "$servers" | jq -s 'length') default servers"

--- a/wiki/Server-Selection.md
+++ b/wiki/Server-Selection.md
@@ -38,7 +38,7 @@ To connect to a specific NordVPN server, use its short hostname. Four patterns a
 
 Specific servers are:
 - Looked up through the NordVPN API by hostname (not DNS) to obtain their address and metadata
-- Given `load=0` so they always appear first in the server list
+- Carrying their real current load, so in a mixed pool they compete with the other filters' results — list a server as the only value to force selection
 - Placed in either `COUNTRY` or `CITY` — both work the same way
 
 **Invalid formats** (will be treated as country/city names): `usa1` (3-letter prefix), `u1` (1 letter), `us` (no digits).
@@ -51,7 +51,7 @@ Reference lists:
 
 ## Selection Behavior
 
-- **Specific servers** (e.g., `es1234`): Placed at the top of the list with `load=0`
+- **Specific servers** (e.g., `es1234`): Join the pool with their real current load; list one alone to force it
 - **Multiple locations**: Combined and sorted by server load (lowest first)
 - **Single location**: Keeps NordVPN's recommended order
 - **RANDOM_TOP=N**: After filtering and sorting, randomly picks from the top N servers


### PR DESCRIPTION
Back-port from the nordvpn-wg sibling (azinchen/nordvpn-wg#230, where the same latent issue was found and fixed):

- **The group fallback couldn't fall back.** When COUNTRY/CITY filters produced nothing, the "default recommended servers" request still included the group filter, so a group with no servers for the selected technology returned empty again and the container failed hard — while the wiki promises a graceful fallback to the recommended pool. The filter is kept on the first attempt (with only `GROUP` set, that path is the primary query, not a fallback) and dropped on a second attempt with a warning.
- **Docs: specific servers no longer get `load=0`.** Server-Selection still described the old DNS-stub behavior ("always appear first"); since the API-based lookup they carry their real load and compete in a mixed pool. The page now documents the actual behavior (list a server alone to force it).