### PR TITLE
Robust healthcheck status parsing; IPT/IP6T defaults under set -u

### DIFF
--- a/root/usr/local/bin/backend-functions
+++ b/root/usr/local/bin/backend-functions
@@ -1,8 +1,13 @@
 #!/bin/sh
 # shellcheck shell=sh
 
-# Reuse backend selected by entrypoint
+# Reuse backend selected by entrypoint. Default the backends afterwards so
+# scripts running under `set -u` fail with a clear log line instead of an
+# "IPT: parameter not set" abort when backend.env is missing (e.g. a manual
+# docker exec after /run was cleared).
 [ -r /run/xt/backend.env ] && . /run/xt/backend.env
+IPT="${IPT:-iptables}"
+IP6T="${IP6T:-}"
 
 # Create lowercase copies of environment variables
 # Boolean flags are normalized to "true"/"false" (accepting "true" or "1"),

--- a/root/usr/local/bin/vpn-healthcheck
+++ b/root/usr/local/bin/vpn-healthcheck
@@ -11,9 +11,11 @@ log "$SCRIPT_NAME" "Starting VPN health check"
 
 httpreq()
 {
-    case "$(curl -s --max-time 2 -I "$1" | sed 's/^[^ ]*  *\([0-9]\).*/\1/; 1q')" in
-        [23]) return 0;;
-        5) return 1;;
+    # Same probe style as vpn-healthcheck-probe: let curl report the status
+    # code directly instead of sed-parsing the raw header line (which broke
+    # on anything but a plain 'HTTP/x.y NNN' first line).
+    case "$(curl -s --max-time 2 -o /dev/null -w '%{http_code}' -I "$1" 2>/dev/null || printf '000')" in
+        2*|3*) return 0;;
         *) return 1;;
     esac
 }


### PR DESCRIPTION
Back-port of two small hardening fixes from the nordvpn-wg sibling (azinchen/nordvpn-wg#234 and part of #230):

- **`httpreq`** sed-parsed the first header line of `curl -I` output — fragile on anything but a plain `HTTP/x.y NNN` status line, and inconsistent with `vpn-healthcheck-probe`. It now uses `curl -o /dev/null -w '%{http_code}'` and accepts 2xx/3xx, matching the probe, with `000` on transport failure.
- **`IPT`/`IP6T`** get defaults after sourcing `backend.env`, so a manual invocation without the file (e.g. `docker exec` after `/run` was cleared) fails with a clear message instead of a `set -u` "parameter not set" abort.

No behavior change for healthy endpoints or normal boots.